### PR TITLE
fix: prevent phantom deployments and add stale job cleanup

### DIFF
--- a/src/DotnetFleet.Coordinator/CoordinatorHostBuilder.cs
+++ b/src/DotnetFleet.Coordinator/CoordinatorHostBuilder.cs
@@ -144,6 +144,37 @@ public static class CoordinatorHostBuilder
             await db.Database.ExecuteSqlRawAsync("ALTER TABLE \"DeploymentJobs\" ADD COLUMN \"CancellationRequestedAt\" INTEGER NULL");
         }
 
+        // ── Startup reconciliation ─────────────────────────────────────────
+        // Jobs that were Running or Assigned during the last shutdown can never
+        // complete because the worker context is lost. Fail them so they don't
+        // sit around forever.
+        var orphanedJobs = await db.DeploymentJobs
+            .Where(j => j.Status == JobStatus.Running || j.Status == JobStatus.Assigned)
+            .ToListAsync();
+
+        var now = DateTimeOffset.UtcNow;
+        foreach (var job in orphanedJobs)
+        {
+            job.Status = JobStatus.Failed;
+            job.FinishedAt = now;
+            job.ErrorMessage = "Failed during coordinator restart — job state could not be recovered.";
+        }
+
+        // Workers will re-register via heartbeat; start them all as Offline.
+        var activeWorkers = await db.Workers
+            .Where(w => w.Status != WorkerStatus.Offline)
+            .ToListAsync();
+
+        foreach (var w in activeWorkers)
+            w.Status = WorkerStatus.Offline;
+
+        if (orphanedJobs.Count > 0 || activeWorkers.Count > 0)
+        {
+            await db.SaveChangesAsync();
+            Log.Information("Startup reconciliation: failed {Jobs} orphaned job(s), reset {Workers} worker(s) to Offline",
+                orphanedJobs.Count, activeWorkers.Count);
+        }
+
         var storage = app.Services.GetRequiredService<IFleetStorage>();
         if (!await storage.AnyUserExistsAsync())
         {

--- a/src/DotnetFleet.Coordinator/Data/EfFleetStorage.cs
+++ b/src/DotnetFleet.Coordinator/Data/EfFleetStorage.cs
@@ -155,6 +155,74 @@ public class EfFleetStorage(IDbContextFactory<FleetDbContext> factory) : IFleetS
         await db.SaveChangesAsync(ct);
     }
 
+    // Stale detection
+    public async Task<int> MarkOfflineWorkersAsync(TimeSpan staleThreshold, CancellationToken ct = default)
+    {
+        await using var db = await factory.CreateDbContextAsync(ct);
+        var cutoff = DateTimeOffset.UtcNow - staleThreshold;
+
+        var staleWorkers = await db.Workers
+            .Where(w => w.Status != WorkerStatus.Offline && w.LastSeenAt != null && w.LastSeenAt < cutoff)
+            .ToListAsync(ct);
+
+        foreach (var worker in staleWorkers)
+            worker.Status = WorkerStatus.Offline;
+
+        if (staleWorkers.Count > 0)
+            await db.SaveChangesAsync(ct);
+
+        return staleWorkers.Count;
+    }
+
+    public async Task<IReadOnlyList<Guid>> FailStaleJobsAsync(TimeSpan staleThreshold, CancellationToken ct = default)
+    {
+        await using var db = await factory.CreateDbContextAsync(ct);
+        var cutoff = DateTimeOffset.UtcNow - staleThreshold;
+
+        var staleJobs = await db.DeploymentJobs
+            .Where(j => (j.Status == JobStatus.Running || j.Status == JobStatus.Assigned)
+                        && j.WorkerId != null)
+            .Join(db.Workers.Where(w => w.LastSeenAt != null && w.LastSeenAt < cutoff),
+                  j => j.WorkerId, w => w.Id, (j, _) => j)
+            .ToListAsync(ct);
+
+        var now = DateTimeOffset.UtcNow;
+        foreach (var job in staleJobs)
+        {
+            job.Status = JobStatus.Failed;
+            job.FinishedAt = now;
+            job.ErrorMessage = "Worker unresponsive — marked as failed by stale job reaper.";
+        }
+
+        if (staleJobs.Count > 0)
+            await db.SaveChangesAsync(ct);
+
+        return staleJobs.Select(j => j.Id).ToList();
+    }
+
+    public async Task<IReadOnlyList<Guid>> FailTimedOutJobsAsync(TimeSpan queuedTimeout, CancellationToken ct = default)
+    {
+        await using var db = await factory.CreateDbContextAsync(ct);
+        var cutoff = DateTimeOffset.UtcNow - queuedTimeout;
+
+        var timedOutJobs = await db.DeploymentJobs
+            .Where(j => j.Status == JobStatus.Queued && j.EnqueuedAt < cutoff)
+            .ToListAsync(ct);
+
+        var now = DateTimeOffset.UtcNow;
+        foreach (var job in timedOutJobs)
+        {
+            job.Status = JobStatus.Failed;
+            job.FinishedAt = now;
+            job.ErrorMessage = "Timed out — no worker claimed this job within the allowed window.";
+        }
+
+        if (timedOutJobs.Count > 0)
+            await db.SaveChangesAsync(ct);
+
+        return timedOutJobs.Select(j => j.Id).ToList();
+    }
+
     // Repo caches
     public async Task<IReadOnlyList<RepoCache>> GetRepoCachesAsync(Guid workerId, CancellationToken ct = default)
     {

--- a/src/DotnetFleet.Coordinator/Endpoints/WorkerEndpoints.cs
+++ b/src/DotnetFleet.Coordinator/Endpoints/WorkerEndpoints.cs
@@ -105,7 +105,8 @@ public static class WorkerEndpoints
         if (worker is null) return Results.NotFound();
 
         worker.LastSeenAt = DateTimeOffset.UtcNow;
-        worker.Status = WorkerStatus.Online;
+        if (worker.Status == WorkerStatus.Offline)
+            worker.Status = WorkerStatus.Online;
         await storage.UpdateWorkerAsync(worker);
         return Results.Ok();
     }

--- a/src/DotnetFleet.Coordinator/Services/PollingBackgroundService.cs
+++ b/src/DotnetFleet.Coordinator/Services/PollingBackgroundService.cs
@@ -74,6 +74,15 @@ public class PollingBackgroundService : BackgroundService
             return;
         }
 
+        // First poll: just record the baseline SHA — don't auto-deploy.
+        if (project.LastPolledCommitSha is null)
+        {
+            logger.LogInformation("First poll for {Name}/{Branch}: recording baseline SHA {Sha}", project.Name, project.Branch, latestSha);
+            project.LastPolledCommitSha = latestSha;
+            await storage.UpdateProjectAsync(project);
+            return;
+        }
+
         if (latestSha == project.LastPolledCommitSha)
         {
             await storage.UpdateProjectAsync(project);

--- a/src/DotnetFleet.Coordinator/Services/StaleJobReaperService.cs
+++ b/src/DotnetFleet.Coordinator/Services/StaleJobReaperService.cs
@@ -1,0 +1,76 @@
+using DotnetFleet.Core.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace DotnetFleet.Coordinator.Services;
+
+/// <summary>
+/// Periodically detects workers that stopped heartbeating and marks their
+/// in-flight jobs as failed so they don't stay "Running" forever.
+/// </summary>
+public class StaleJobReaperService : BackgroundService
+{
+    private readonly IServiceScopeFactory scopeFactory;
+    private readonly LogBroadcaster broadcaster;
+    private readonly ILogger<StaleJobReaperService> logger;
+
+    private static readonly TimeSpan TickInterval = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan StaleThreshold = TimeSpan.FromSeconds(90);
+    private static readonly TimeSpan QueuedTimeout = TimeSpan.FromMinutes(10);
+
+    public StaleJobReaperService(
+        IServiceScopeFactory scopeFactory,
+        LogBroadcaster broadcaster,
+        ILogger<StaleJobReaperService> logger)
+    {
+        this.scopeFactory = scopeFactory;
+        this.broadcaster = broadcaster;
+        this.logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ReapAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Unhandled error in stale job reaper");
+            }
+
+            await Task.Delay(TickInterval, stoppingToken);
+        }
+    }
+
+    private async Task ReapAsync(CancellationToken ct)
+    {
+        using var scope = scopeFactory.CreateScope();
+        var storage = scope.ServiceProvider.GetRequiredService<IFleetStorage>();
+
+        var offlineCount = await storage.MarkOfflineWorkersAsync(StaleThreshold, ct);
+        if (offlineCount > 0)
+            logger.LogWarning("Marked {Count} worker(s) as offline (no heartbeat for {Threshold}s)", offlineCount, StaleThreshold.TotalSeconds);
+
+        var failedJobIds = await storage.FailStaleJobsAsync(StaleThreshold, ct);
+        if (failedJobIds.Count > 0)
+        {
+            logger.LogWarning("Reaped {Count} stale job(s): {Ids}", failedJobIds.Count, string.Join(", ", failedJobIds));
+
+            foreach (var jobId in failedJobIds)
+                broadcaster.Complete(jobId);
+        }
+
+        var timedOutIds = await storage.FailTimedOutJobsAsync(QueuedTimeout, ct);
+        if (timedOutIds.Count > 0)
+        {
+            logger.LogWarning("Timed out {Count} unclaimed job(s): {Ids}", timedOutIds.Count, string.Join(", ", timedOutIds));
+
+            foreach (var jobId in timedOutIds)
+                broadcaster.Complete(jobId);
+        }
+    }
+}

--- a/src/DotnetFleet.Core/Interfaces/IFleetStorage.cs
+++ b/src/DotnetFleet.Core/Interfaces/IFleetStorage.cs
@@ -51,6 +51,27 @@ public interface IFleetStorage
     Task DeleteUserAsync(Guid id, CancellationToken ct = default);
     Task<bool> AnyUserExistsAsync(CancellationToken ct = default);
 
+    // Stale detection
+    /// <summary>
+    /// Marks workers whose <c>LastSeenAt</c> is older than <paramref name="staleThreshold"/> as <see cref="WorkerStatus.Offline"/>.
+    /// Returns the number of workers affected.
+    /// </summary>
+    Task<int> MarkOfflineWorkersAsync(TimeSpan staleThreshold, CancellationToken ct = default);
+
+    /// <summary>
+    /// Fails jobs that are still <see cref="JobStatus.Running"/> or <see cref="JobStatus.Assigned"/>
+    /// but whose worker has not heartbeated within <paramref name="staleThreshold"/>.
+    /// Returns the IDs of the jobs that were marked as failed.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> FailStaleJobsAsync(TimeSpan staleThreshold, CancellationToken ct = default);
+
+    /// <summary>
+    /// Fails jobs that have been <see cref="JobStatus.Queued"/> longer than <paramref name="queuedTimeout"/>
+    /// without being claimed by a worker.
+    /// Returns the IDs of the jobs that were marked as failed.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> FailTimedOutJobsAsync(TimeSpan queuedTimeout, CancellationToken ct = default);
+
     // Secrets
     /// <summary>Returns global secrets when <paramref name="projectId"/> is null, or project-scoped secrets otherwise.</summary>
     Task<IReadOnlyList<Secret>> GetSecretsAsync(Guid? projectId, CancellationToken ct = default);


### PR DESCRIPTION
## Problem

After starting coordinator, worker, and GUI, a deployment appears that nobody initiated. It has no logs, does nothing, and the coordinator never cleans it up.

## Root cause — 3 chained bugs

### 🐛 Bug 1 — Phantom deployment on first poll
`PollingBackgroundService.PollProjectAsync` compared `latestSha == project.LastPolledCommitSha` — when `LastPolledCommitSha` is `null` (first poll or fresh DB), this always fails, auto-creating a deployment even though no commit actually changed.

### 🐛 Bug 2 — No startup reconciliation
`CoordinatorHostBuilder.InitializeDatabaseAsync` never cleaned up `Running`/`Assigned` jobs from a previous session. They survived in SQLite and became orphans forever.

### 🐛 Bug 3 — Reaper ignores Queued jobs
`FailStaleJobsAsync` only failed jobs whose assigned worker had gone stale. A `Queued` job with no worker sat there indefinitely with no timeout.

### 🐛 Bonus — Heartbeat overwrites Busy status
`WorkerEndpoints.Heartbeat` unconditionally set `Status = Online`, overwriting `Busy` every 30s.

## Fixes

| File | Change |
|------|--------|
| `PollingBackgroundService.cs` | First poll records baseline SHA without creating a job |
| `CoordinatorHostBuilder.cs` | On startup, fail orphaned Running/Assigned jobs and reset workers to Offline |
| `IFleetStorage.cs` | New `FailTimedOutJobsAsync` interface method |
| `EfFleetStorage.cs` | Implementation: fail Queued jobs older than threshold |
| `StaleJobReaperService.cs` | Call `FailTimedOutJobsAsync` with 10-minute timeout |
| `WorkerEndpoints.cs` | Only set Online if worker was Offline (preserve Busy) |

## Testing

All 48 existing tests pass ✅