### PR TITLE
fix: thread-safe LogBroadcaster and SSE streaming fixes

### DIFF
--- a/src/DotnetFleet.Coordinator/Endpoints/JobEndpoints.cs
+++ b/src/DotnetFleet.Coordinator/Endpoints/JobEndpoints.cs
@@ -56,28 +56,31 @@ public static class JobEndpoints
 
         await httpContext.Response.Body.FlushAsync(ct);
 
-        // Send existing logs first
-        var existing = await storage.GetLogsAsync(id, ct);
-        foreach (var entry in existing)
-        {
-            await WriteEventAsync(httpContext.Response, entry.Line, ct);
-        }
-
-        // If job is already in a terminal state, close the stream
-        var job = await storage.GetJobAsync(id, ct);
-        bool isTerminal = job is null
-            || job.Status is JobStatus.Succeeded or JobStatus.Failed or JobStatus.Cancelled;
-
-        if (isTerminal) return;
-
-        // Subscribe to new log lines (only for running / queued jobs)
+        // Subscribe BEFORE reading existing logs so no messages are lost
+        // in the window between the DB read and the subscription.
         var channel = broadcaster.Subscribe(id);
         try
         {
+            // Send existing logs first
+            var existing = await storage.GetLogsAsync(id, ct);
+            foreach (var entry in existing)
+            {
+                await WriteEventAsync(httpContext.Response, entry.Line, ct);
+            }
+
+            // If job is already in a terminal state, close the stream
+            var job = await storage.GetJobAsync(id, ct);
+            bool isTerminal = job is null
+                || job.Status is JobStatus.Succeeded or JobStatus.Failed or JobStatus.Cancelled;
+
+            if (isTerminal) return;
+
+            // Stream new log lines as they arrive
             var heartbeatInterval = TimeSpan.FromSeconds(15);
+            ValueTask<string> pendingRead = channel.Reader.ReadAsync(ct);
             while (!ct.IsCancellationRequested)
             {
-                var readTask = channel.Reader.ReadAsync(ct).AsTask();
+                var readTask = pendingRead.AsTask();
                 var delayTask = Task.Delay(heartbeatInterval, ct);
                 var winner = await Task.WhenAny(readTask, delayTask);
 
@@ -85,6 +88,7 @@ public static class JobEndpoints
                 {
                     var line = await readTask;
                     await WriteEventAsync(httpContext.Response, line, ct);
+                    pendingRead = channel.Reader.ReadAsync(ct);
                 }
                 else
                 {

--- a/src/DotnetFleet.Coordinator/Services/LogBroadcaster.cs
+++ b/src/DotnetFleet.Coordinator/Services/LogBroadcaster.cs
@@ -6,6 +6,7 @@ namespace DotnetFleet.Coordinator.Services;
 /// <summary>
 /// In-memory pub/sub for real-time log streaming via SSE.
 /// Workers publish lines; SSE handlers subscribe to receive them.
+/// All subscriber-list access is synchronized via lock.
 /// </summary>
 public class LogBroadcaster
 {
@@ -19,28 +20,36 @@ public class LogBroadcaster
             SingleWriter = false
         });
 
-        subscribers.GetOrAdd(jobId, _ => []).Add(channel);
+        var list = subscribers.GetOrAdd(jobId, _ => []);
+        lock (list) { list.Add(channel); }
         return channel;
     }
 
     public void Unsubscribe(Guid jobId, Channel<string> channel)
     {
         if (subscribers.TryGetValue(jobId, out var list))
-            list.Remove(channel);
+            lock (list) { list.Remove(channel); }
     }
 
     public void Publish(Guid jobId, string line)
     {
         if (!subscribers.TryGetValue(jobId, out var list)) return;
-        foreach (var channel in list)
+
+        Channel<string>[] snapshot;
+        lock (list) { snapshot = [.. list]; }
+
+        foreach (var channel in snapshot)
             channel.Writer.TryWrite(line);
     }
 
     public void Complete(Guid jobId)
     {
-        if (!subscribers.TryGetValue(jobId, out var list)) return;
-        foreach (var channel in list)
+        if (!subscribers.TryRemove(jobId, out var list)) return;
+
+        Channel<string>[] snapshot;
+        lock (list) { snapshot = [.. list]; }
+
+        foreach (var channel in snapshot)
             channel.Writer.TryComplete();
-        subscribers.TryRemove(jobId, out _);
     }
 }

--- a/tests/DotnetFleet.Tests/LogBroadcasterTests.cs
+++ b/tests/DotnetFleet.Tests/LogBroadcasterTests.cs
@@ -89,4 +89,36 @@ public class LogBroadcasterTests
 
         lines.Should().BeEmpty();
     }
+
+    [Fact]
+    public async Task Concurrent_publish_and_subscribe_does_not_throw()
+    {
+        var broadcaster = new LogBroadcaster();
+        var jobId = Guid.NewGuid();
+
+        // Hammer the broadcaster from multiple threads simultaneously.
+        // Before the lock fix this would throw InvalidOperationException
+        // ("Collection was modified during enumeration").
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var publishTask = Task.Run(async () =>
+        {
+            for (var i = 0; i < 500 && !cts.IsCancellationRequested; i++)
+                broadcaster.Publish(jobId, $"line-{i}");
+        });
+
+        var subscribeTask = Task.Run(async () =>
+        {
+            var channels = new List<System.Threading.Channels.Channel<string>>();
+            for (var i = 0; i < 500 && !cts.IsCancellationRequested; i++)
+            {
+                var ch = broadcaster.Subscribe(jobId);
+                channels.Add(ch);
+                if (i % 3 == 0)
+                    broadcaster.Unsubscribe(jobId, ch);
+            }
+        });
+
+        var act = () => Task.WhenAll(publishTask, subscribeTask);
+        await act.Should().NotThrowAsync();
+    }
 }


### PR DESCRIPTION
## Problem

After enqueuing a deployment, the GUI shows no streaming logs — the deployment appears frozen even though the worker is running.

## Root cause — Thread-unsafe `LogBroadcaster`

`LogBroadcaster` uses `ConcurrentDictionary<Guid, List<Channel<string>>>` but the `List<T>` values are accessed concurrently without synchronization from 4 different threads:

| Method | Thread | Operation |
|---|---|---|
| `Subscribe` | SSE request | `list.Add(channel)` |
| `Publish` | Worker POST | `foreach (var ch in list)` |
| `Unsubscribe` | SSE cleanup | `list.Remove(channel)` |
| `Complete` | Reaper/Worker | `foreach` + `TryRemove` |

When `Publish` races with `Subscribe`/`Unsubscribe`, the `foreach` throws `InvalidOperationException: Collection was modified` → `AppendLogs` returns 500 → the worker silently drops the log chunk → SSE subscribers never receive it → **deployment looks frozen**.

## Additional issues fixed

### Race window in SSE endpoint
`StreamLogs` was reading existing logs from DB, then subscribing to the broadcaster. Any log published in that gap was lost. **Fix:** Subscribe first, then read DB.

### `SingleReader` contract violation
The heartbeat loop created a new `ReadAsync` each iteration while the previous was still pending, violating the `SingleReader = true` contract. **Fix:** Hoist `ReadAsync` and only renew after consumption.

## Changes

| File | Change |
|------|--------|
| `LogBroadcaster.cs` | `lock` all `List<Channel>` access; snapshot before iterating |
| `JobEndpoints.cs` | Subscribe before DB read; hoist `ReadAsync` outside loop |
| `LogBroadcasterTests.cs` | New concurrent stress test |

## Testing

All 49 tests pass ✅ (48 existing + 1 new concurrency test)