### PR TITLE
fix: recover stuck Assigned jobs and harden ExecuteJobAsync error handling

### DIFF
--- a/src/DotnetFleet.Coordinator/Data/EfFleetStorage.cs
+++ b/src/DotnetFleet.Coordinator/Data/EfFleetStorage.cs
@@ -223,6 +223,31 @@ public class EfFleetStorage(IDbContextFactory<FleetDbContext> factory) : IFleetS
         return timedOutJobs.Select(j => j.Id).ToList();
     }
 
+    public async Task<IReadOnlyList<Guid>> FailStuckAssignedJobsAsync(TimeSpan assignedTimeout, CancellationToken ct = default)
+    {
+        await using var db = await factory.CreateDbContextAsync(ct);
+        var cutoff = DateTimeOffset.UtcNow - assignedTimeout;
+
+        // Jobs stuck in Assigned: claimed by a worker but never transitioned to Running.
+        // EnqueuedAt is used as the baseline because there is no separate AssignedAt timestamp.
+        var stuckJobs = await db.DeploymentJobs
+            .Where(j => j.Status == JobStatus.Assigned && j.StartedAt == null && j.EnqueuedAt < cutoff)
+            .ToListAsync(ct);
+
+        var now = DateTimeOffset.UtcNow;
+        foreach (var job in stuckJobs)
+        {
+            job.Status = JobStatus.Failed;
+            job.FinishedAt = now;
+            job.ErrorMessage = "Timed out — worker claimed this job but never started it.";
+        }
+
+        if (stuckJobs.Count > 0)
+            await db.SaveChangesAsync(ct);
+
+        return stuckJobs.Select(j => j.Id).ToList();
+    }
+
     // Repo caches
     public async Task<IReadOnlyList<RepoCache>> GetRepoCachesAsync(Guid workerId, CancellationToken ct = default)
     {

--- a/src/DotnetFleet.Coordinator/Services/StaleJobReaperService.cs
+++ b/src/DotnetFleet.Coordinator/Services/StaleJobReaperService.cs
@@ -18,6 +18,7 @@ public class StaleJobReaperService : BackgroundService
     private static readonly TimeSpan TickInterval = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan StaleThreshold = TimeSpan.FromSeconds(90);
     private static readonly TimeSpan QueuedTimeout = TimeSpan.FromMinutes(10);
+    private static readonly TimeSpan AssignedTimeout = TimeSpan.FromMinutes(5);
 
     public StaleJobReaperService(
         IServiceScopeFactory scopeFactory,
@@ -70,6 +71,15 @@ public class StaleJobReaperService : BackgroundService
             logger.LogWarning("Timed out {Count} unclaimed job(s): {Ids}", timedOutIds.Count, string.Join(", ", timedOutIds));
 
             foreach (var jobId in timedOutIds)
+                broadcaster.Complete(jobId);
+        }
+
+        var stuckAssignedIds = await storage.FailStuckAssignedJobsAsync(AssignedTimeout, ct);
+        if (stuckAssignedIds.Count > 0)
+        {
+            logger.LogWarning("Failed {Count} stuck Assigned job(s): {Ids}", stuckAssignedIds.Count, string.Join(", ", stuckAssignedIds));
+
+            foreach (var jobId in stuckAssignedIds)
                 broadcaster.Complete(jobId);
         }
     }

--- a/src/DotnetFleet.Core/Interfaces/IFleetStorage.cs
+++ b/src/DotnetFleet.Core/Interfaces/IFleetStorage.cs
@@ -72,6 +72,14 @@ public interface IFleetStorage
     /// </summary>
     Task<IReadOnlyList<Guid>> FailTimedOutJobsAsync(TimeSpan queuedTimeout, CancellationToken ct = default);
 
+    /// <summary>
+    /// Fails jobs that have been <see cref="JobStatus.Assigned"/> longer than <paramref name="assignedTimeout"/>
+    /// without transitioning to <see cref="JobStatus.Running"/>. This catches jobs that were claimed
+    /// by a worker but never started (e.g. due to a crash between claim and execution).
+    /// Returns the IDs of the jobs that were marked as failed.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> FailStuckAssignedJobsAsync(TimeSpan assignedTimeout, CancellationToken ct = default);
+
     // Secrets
     /// <summary>Returns global secrets when <paramref name="projectId"/> is null, or project-scoped secrets otherwise.</summary>
     Task<IReadOnlyList<Secret>> GetSecretsAsync(Guid? projectId, CancellationToken ct = default);

--- a/src/DotnetFleet.Worker/RemoteWorkerBackgroundService.cs
+++ b/src/DotnetFleet.Worker/RemoteWorkerBackgroundService.cs
@@ -105,28 +105,6 @@ public class RemoteWorkerBackgroundService : BackgroundService
     {
         logger.LogInformation("Starting job {JobId} for project {ProjectId}", job.Id, job.ProjectId);
 
-        await SetWorkerBusy(true, ct);
-        await jobSource.ReportJobStartedAsync(job.Id, workerId, ct);
-
-        var project = await coordinator.GetProjectAsync(job.ProjectId, ct);
-        if (project is null)
-        {
-            await jobSource.ReportJobCompletedAsync(job.Id, false, "Project not found", ct);
-            await SetWorkerBusy(false, ct);
-            return;
-        }
-
-        await ManageDiskSpaceAsync(ct);
-
-        var localPath = Path.Combine(repoStoragePath, SanitizeName(project.Name));
-
-        using var cancelCts = new CancellationTokenSource();
-        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, cancelCts.Token);
-        var jobCt = linkedCts.Token;
-
-        // Background task: poll coordinator for cancellation requests
-        _ = PollForCancellationAsync(job.Id, cancelCts, ct);
-
         await using var logBuffer = new LogChunkBuffer(
             send: (chunk, token) => jobSource.SendLogChunkAsync(job.Id, chunk, token),
             ct: ct);
@@ -139,6 +117,26 @@ public class RemoteWorkerBackgroundService : BackgroundService
 
         try
         {
+            await SetWorkerBusy(true, ct);
+            await jobSource.ReportJobStartedAsync(job.Id, workerId, ct);
+
+            var project = await coordinator.GetProjectAsync(job.ProjectId, ct);
+            if (project is null)
+            {
+                await jobSource.ReportJobCompletedAsync(job.Id, false, "Project not found", ct);
+                return;
+            }
+
+            await ManageDiskSpaceAsync(ct);
+
+            var localPath = Path.Combine(repoStoragePath, SanitizeName(project.Name));
+
+            using var cancelCts = new CancellationTokenSource();
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, cancelCts.Token);
+            var jobCt = linkedCts.Token;
+
+            _ = PollForCancellationAsync(job.Id, cancelCts, ct);
+
             await Log($"=== DotnetFleet Worker | Job {job.Id} ===");
             await Log($"Project: {project.Name} | Branch: {project.Branch}");
             await Log($"Git URL: {project.GitUrl}");
@@ -194,21 +192,46 @@ public class RemoteWorkerBackgroundService : BackgroundService
                 await jobSource.ReportJobCompletedAsync(job.Id, false, error, ct);
             }
         }
-        catch (OperationCanceledException) when (cancelCts.IsCancellationRequested)
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
-            await Log("=== Deployment CANCELLED by user ===");
-            await logBuffer.FlushAsync();
-            await jobSource.ReportJobCompletedAsync(job.Id, false, "Cancelled by user", ct);
+            throw; // Host shutting down — let it propagate
+        }
+        catch (OperationCanceledException)
+        {
+            // User-initiated cancellation
+            try
+            {
+                await Log("=== Deployment CANCELLED by user ===");
+                await logBuffer.FlushAsync();
+            }
+            catch { /* best effort */ }
+            await ReportJobFailedBestEffort(job.Id, "Cancelled by user", ct);
         }
         catch (Exception ex)
         {
-            await Log($"[EXCEPTION] {ex.Message}");
-            await logBuffer.FlushAsync();
-            await jobSource.ReportJobCompletedAsync(job.Id, false, ex.Message, ct);
+            try
+            {
+                await Log($"[EXCEPTION] {ex.Message}");
+                await logBuffer.FlushAsync();
+            }
+            catch { /* best effort */ }
+            await ReportJobFailedBestEffort(job.Id, ex.Message, ct);
         }
         finally
         {
             await SetWorkerBusy(false, ct);
+        }
+    }
+
+    private async Task ReportJobFailedBestEffort(Guid jobId, string error, CancellationToken ct)
+    {
+        try
+        {
+            await jobSource.ReportJobCompletedAsync(jobId, false, error, ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to report job {JobId} as failed (error: {Error})", jobId, error);
         }
     }
 

--- a/tests/DotnetFleet.Tests/StaleJobReaperTests.cs
+++ b/tests/DotnetFleet.Tests/StaleJobReaperTests.cs
@@ -1,0 +1,113 @@
+using DotnetFleet.Coordinator.Data;
+using DotnetFleet.Core.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace DotnetFleet.Tests;
+
+/// <summary>
+/// Tests for the stale/stuck job reaping storage methods to verify
+/// that orphaned Assigned/Queued jobs are eventually cleaned up.
+/// </summary>
+public class StaleJobReaperTests : IDisposable
+{
+    private readonly string dbPath;
+    private readonly IDbContextFactory<FleetDbContext> factory;
+
+    public StaleJobReaperTests()
+    {
+        dbPath = Path.Combine(Path.GetTempPath(), $"fleet-reaper-{Guid.NewGuid():N}.db");
+        var options = new DbContextOptionsBuilder<FleetDbContext>()
+            .UseSqlite($"Data Source={dbPath}")
+            .Options;
+        factory = new InlineFactory(options);
+
+        using var db = factory.CreateDbContext();
+        db.Database.EnsureCreated();
+    }
+
+    private sealed class InlineFactory(DbContextOptions<FleetDbContext> options)
+        : IDbContextFactory<FleetDbContext>
+    {
+        public FleetDbContext CreateDbContext() => new(options);
+    }
+
+    public void Dispose()
+    {
+        try { File.Delete(dbPath); } catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task FailStuckAssignedJobsAsync_fails_assigned_jobs_past_timeout()
+    {
+        var storage = new EfFleetStorage(factory);
+        var projectId = Guid.NewGuid();
+        var workerId = Guid.NewGuid();
+
+        await storage.AddProjectAsync(new Project
+        {
+            Id = projectId, Name = "test", GitUrl = "https://example.com/r.git", Branch = "main"
+        });
+
+        // Assigned job created 10 minutes ago (past the 5-minute timeout)
+        var stuckJob = new DeploymentJob
+        {
+            Id = Guid.NewGuid(),
+            ProjectId = projectId,
+            WorkerId = workerId,
+            Status = JobStatus.Assigned,
+            EnqueuedAt = DateTimeOffset.UtcNow.AddMinutes(-10),
+            StartedAt = null
+        };
+        await storage.AddJobAsync(stuckJob);
+
+        // Recent Assigned job (should NOT be reaped)
+        var recentJob = new DeploymentJob
+        {
+            Id = Guid.NewGuid(),
+            ProjectId = projectId,
+            WorkerId = workerId,
+            Status = JobStatus.Assigned,
+            EnqueuedAt = DateTimeOffset.UtcNow.AddSeconds(-30),
+            StartedAt = null
+        };
+        await storage.AddJobAsync(recentJob);
+
+        var failedIds = await storage.FailStuckAssignedJobsAsync(TimeSpan.FromMinutes(5));
+
+        failedIds.Should().ContainSingle().Which.Should().Be(stuckJob.Id);
+
+        var job = await storage.GetJobAsync(stuckJob.Id);
+        job!.Status.Should().Be(JobStatus.Failed);
+        job.ErrorMessage.Should().Contain("never started");
+
+        var recent = await storage.GetJobAsync(recentJob.Id);
+        recent!.Status.Should().Be(JobStatus.Assigned);
+    }
+
+    [Fact]
+    public async Task FailStuckAssignedJobsAsync_ignores_running_jobs()
+    {
+        var storage = new EfFleetStorage(factory);
+        var projectId = Guid.NewGuid();
+
+        await storage.AddProjectAsync(new Project
+        {
+            Id = projectId, Name = "test2", GitUrl = "https://example.com/r.git", Branch = "main"
+        });
+
+        // Running job with StartedAt set — should NOT be reaped
+        var runningJob = new DeploymentJob
+        {
+            Id = Guid.NewGuid(),
+            ProjectId = projectId,
+            WorkerId = Guid.NewGuid(),
+            Status = JobStatus.Running,
+            EnqueuedAt = DateTimeOffset.UtcNow.AddMinutes(-10),
+            StartedAt = DateTimeOffset.UtcNow.AddMinutes(-9)
+        };
+        await storage.AddJobAsync(runningJob);
+
+        var failedIds = await storage.FailStuckAssignedJobsAsync(TimeSpan.FromMinutes(5));
+        failedIds.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Problem

Enqueued jobs could silently get stuck and "do nothing" due to two related bugs:

### Bug 1: `ExecuteJobAsync` error-handling gap (Worker)

`ReportJobStartedAsync`, `GetProjectAsync`, and `ManageDiskSpaceAsync` were called **outside** the `try/catch/finally` block. If any of these threw an exception:
- The job was already claimed (`Queued → Assigned`) but never completed
- `SetWorkerBusy(false)` was never called → worker permanently marked as `Busy`
- The exception propagated to `PollLoopAsync` which logged it but couldn't recover
- No cleanup mechanism existed for this scenario

### Bug 2: No timeout for stuck Assigned jobs (Coordinator)

- `FailTimedOutJobsAsync` only handled `Queued` jobs
- `FailStaleJobsAsync` only handled jobs whose worker stopped heartbeating
- Jobs stuck in `Assigned` with a **live, heartbeating** worker were orphaned forever

## Fix

1. **Worker**: Wrapped the entire `ExecuteJobAsync` body in a single `try/catch/finally` so `SetWorkerBusy(false)` and `ReportJobCompleted(failed)` are **always** called. Added `ReportJobFailedBestEffort` helper for error paths.

2. **Coordinator**: Added `FailStuckAssignedJobsAsync` — fails jobs stuck in `Assigned` (never reached `Running`) for more than 5 minutes. Called by `StaleJobReaperService` every 30s as a safety net.

## Files changed

| File | Change |
|------|--------|
| `RemoteWorkerBackgroundService.cs` | Restructured `ExecuteJobAsync` — all code inside try/catch/finally |
| `IFleetStorage.cs` | Added `FailStuckAssignedJobsAsync` interface method |
| `EfFleetStorage.cs` | Implemented `FailStuckAssignedJobsAsync` |
| `StaleJobReaperService.cs` | Added 5-min Assigned timeout reaping |
| `StaleJobReaperTests.cs` | 2 new tests for stuck Assigned job cleanup |

## Tests

All 51 tests pass (49 existing + 2 new).