### PR TITLE
feat: SSE status feedback for queued jobs + worker startup retry

### DIFF
--- a/src/DotnetFleet.Api.Client/FleetApiClient.cs
+++ b/src/DotnetFleet.Api.Client/FleetApiClient.cs
@@ -143,6 +143,20 @@ public class FleetApiClient
         Guid jobId,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
     {
+        await foreach (var evt in StreamJobEventsAsync(jobId, ct))
+        {
+            if (evt.Type == SseEventType.Log)
+                yield return evt.Data;
+        }
+    }
+
+    /// <summary>
+    /// Returns an async enumerable of SSE events (log lines and status updates).
+    /// </summary>
+    public async IAsyncEnumerable<SseEvent> StreamJobEventsAsync(
+        Guid jobId,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+    {
         // Use the dedicated streamingHttp (no Timeout) so the SSE connection stays open.
         using var response = await streamingHttp.GetAsync($"/api/jobs/{jobId}/logs",
             HttpCompletionOption.ResponseHeadersRead, ct);
@@ -151,18 +165,36 @@ public class FleetApiClient
         await using var stream = await response.Content.ReadAsStreamAsync(ct);
         using var reader = new System.IO.StreamReader(stream);
 
+        string? currentEventType = null;
+
         while (!ct.IsCancellationRequested)
         {
             var line = await reader.ReadLineAsync(ct);
             if (line is null) break;
 
-            // SSE: skip comment/keep-alive lines (start with ':') and blank separators
-            if (line.Length == 0 || line[0] == ':') continue;
+            // SSE: skip comment/keep-alive lines (start with ':')
+            if (line.Length > 0 && line[0] == ':') continue;
+
+            // Blank line = end of event block; reset event type for next block
+            if (line.Length == 0) { currentEventType = null; continue; }
+
+            if (line.StartsWith("event: "))
+            {
+                currentEventType = line[7..];
+                continue;
+            }
 
             if (line.StartsWith("data: "))
-                yield return line[6..];
+            {
+                var data = line[6..];
+                var type = currentEventType == "status" ? SseEventType.Status : SseEventType.Log;
+                yield return new SseEvent(type, data);
+            }
         }
     }
+
+    public enum SseEventType { Log, Status }
+    public record SseEvent(SseEventType Type, string Data);
 
     /// <summary>
     /// Sends a request bypassing <c>HttpClient.Timeout</c> so the response body can be streamed indefinitely.

--- a/src/DotnetFleet.Coordinator/Endpoints/JobEndpoints.cs
+++ b/src/DotnetFleet.Coordinator/Endpoints/JobEndpoints.cs
@@ -42,6 +42,8 @@ public static class JobEndpoints
     /// Server-Sent Events stream of log lines for a given job.
     /// Existing logs are sent first, then new lines are pushed as they arrive.
     /// For completed jobs the stream closes immediately after existing logs.
+    /// While the job is waiting to be picked up, periodic status events are sent
+    /// so the client can show feedback (e.g. "Waiting for an available worker…").
     /// </summary>
     private static async Task StreamLogs(
         Guid id,
@@ -73,15 +75,27 @@ public static class JobEndpoints
             bool isTerminal = job is null
                 || job.Status is JobStatus.Succeeded or JobStatus.Failed or JobStatus.Cancelled;
 
-            if (isTerminal) return;
+            if (isTerminal)
+            {
+                await WriteStatusEventAsync(httpContext.Response, job?.Status ?? JobStatus.Failed, ct);
+                return;
+            }
 
-            // Stream new log lines as they arrive
-            var heartbeatInterval = TimeSpan.FromSeconds(15);
+            // Send initial status so the client shows feedback immediately
+            var lastKnownStatus = job!.Status;
+            await WriteStatusEventAsync(httpContext.Response, lastKnownStatus, ct);
+
+            if (lastKnownStatus == JobStatus.Queued)
+                await WriteEventAsync(httpContext.Response, "⏳ Waiting for an available worker…", ct);
+
+            // Stream new log lines as they arrive, polling job status on each heartbeat
+            // so the client gets timely feedback during the Queued→Running transition.
+            var statusPollInterval = TimeSpan.FromSeconds(5);
             ValueTask<string> pendingRead = channel.Reader.ReadAsync(ct);
             while (!ct.IsCancellationRequested)
             {
                 var readTask = pendingRead.AsTask();
-                var delayTask = Task.Delay(heartbeatInterval, ct);
+                var delayTask = Task.Delay(statusPollInterval, ct);
                 var winner = await Task.WhenAny(readTask, delayTask);
 
                 if (winner == readTask)
@@ -92,10 +106,35 @@ public static class JobEndpoints
                 }
                 else
                 {
-                    // Heartbeat: SSE comment line, ignored by clients but keeps proxies/intermediaries
-                    // from closing the idle connection.
-                    await httpContext.Response.WriteAsync(": keep-alive\n\n", ct);
-                    await httpContext.Response.Body.FlushAsync(ct);
+                    // Poll job status — send an update when it changes, otherwise keep-alive
+                    var current = await storage.GetJobAsync(id, ct);
+
+                    if (current is null
+                        || current.Status is JobStatus.Succeeded or JobStatus.Failed or JobStatus.Cancelled)
+                    {
+                        await WriteStatusEventAsync(httpContext.Response, current?.Status ?? JobStatus.Failed, ct);
+                        break;
+                    }
+
+                    if (current.Status != lastKnownStatus)
+                    {
+                        lastKnownStatus = current.Status;
+                        await WriteStatusEventAsync(httpContext.Response, lastKnownStatus, ct);
+
+                        var transitionMsg = lastKnownStatus switch
+                        {
+                            JobStatus.Assigned => "🔄 Worker assigned, preparing deployment…",
+                            JobStatus.Running => "🚀 Deployment started",
+                            _ => null
+                        };
+                        if (transitionMsg is not null)
+                            await WriteEventAsync(httpContext.Response, transitionMsg, ct);
+                    }
+                    else
+                    {
+                        await httpContext.Response.WriteAsync(": keep-alive\n\n", ct);
+                        await httpContext.Response.Body.FlushAsync(ct);
+                    }
                 }
             }
         }
@@ -110,6 +149,12 @@ public static class JobEndpoints
     private static async Task WriteEventAsync(HttpResponse response, string data, CancellationToken ct)
     {
         await response.WriteAsync($"data: {data}\n\n", ct);
+        await response.Body.FlushAsync(ct);
+    }
+
+    private static async Task WriteStatusEventAsync(HttpResponse response, JobStatus status, CancellationToken ct)
+    {
+        await response.WriteAsync($"event: status\ndata: {status}\n\n", ct);
         await response.Body.FlushAsync(ct);
     }
 

--- a/src/DotnetFleet.Worker/RemoteWorkerBackgroundService.cs
+++ b/src/DotnetFleet.Worker/RemoteWorkerBackgroundService.cs
@@ -56,9 +56,9 @@ public class RemoteWorkerBackgroundService : BackgroundService
             "Worker {Id} started. Coordinator: {Url}. Repos: {Path} (CPM-isolated)",
             workerId, this.options.CoordinatorBaseUrl, repoStoragePath);
 
-        // Initial registration of self with the coordinator (status=Online).
-        try { await coordinator.UpdateStatusAsync(workerId, WorkerStatus.Online, stoppingToken); }
-        catch (Exception ex) { logger.LogWarning(ex, "Initial status announce failed."); }
+        // Announce ourselves as Online with retries — the coordinator may still
+        // be starting up, so we tolerate transient failures.
+        await AnnounceOnlineWithRetryAsync(stoppingToken);
 
         using var heartbeatTimer = new PeriodicTimer(TimeSpan.FromSeconds(this.options.HeartbeatIntervalSeconds));
         using var pollTimer = new PeriodicTimer(TimeSpan.FromSeconds(this.options.PollIntervalSeconds));
@@ -67,6 +67,29 @@ public class RemoteWorkerBackgroundService : BackgroundService
         var pollTask = PollLoopAsync(pollTimer, stoppingToken);
 
         await Task.WhenAll(heartbeatTask, pollTask);
+    }
+
+    private async Task AnnounceOnlineWithRetryAsync(CancellationToken ct)
+    {
+        const int maxAttempts = 5;
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            try
+            {
+                await coordinator.UpdateStatusAsync(workerId, WorkerStatus.Online, ct);
+                logger.LogInformation("Worker announced as Online (attempt {Attempt})", attempt);
+                return;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogWarning(ex, "Status announce attempt {Attempt}/{Max} failed", attempt, maxAttempts);
+                if (attempt < maxAttempts)
+                    await Task.Delay(TimeSpan.FromSeconds(2 * attempt), ct);
+            }
+        }
+        logger.LogError(
+            "Could not announce Online after {Max} attempts — heartbeat will retry in the background",
+            maxAttempts);
     }
 
     private async Task HeartbeatLoopAsync(PeriodicTimer timer, CancellationToken ct)

--- a/src/DotnetFleet/ViewModels/JobDetailViewModel.cs
+++ b/src/DotnetFleet/ViewModels/JobDetailViewModel.cs
@@ -53,7 +53,7 @@ public partial class JobDetailViewModel : ReactiveObject, IDisposable
         _client = client;
         _main = main;
         _parentProject = parentProject;
-        _statusText = job.Status.ToString();
+        _statusText = FormatStatus(job.Status);
 
         BackCommand = ReactiveCommand.Create(GoBack);
         CopyLogsCommand = ReactiveCommand.CreateFromTask(CopyLogsToClipboard);
@@ -167,9 +167,16 @@ public partial class JobDetailViewModel : ReactiveObject, IDisposable
         var buffer = new List<LogLine>(maxBatchSize);
         var lastFlush = Environment.TickCount64;
 
-        await foreach (var line in _client.StreamJobLogsAsync(Job.Id, ct))
+        await foreach (var evt in _client.StreamJobEventsAsync(Job.Id, ct))
         {
-            buffer.Add(LogLine.FromText(line));
+            if (evt.Type == FleetApiClient.SseEventType.Status)
+            {
+                if (Enum.TryParse<JobStatus>(evt.Data, out var status))
+                    Avalonia.Threading.Dispatcher.UIThread.Post(() => StatusText = FormatStatus(status));
+                continue;
+            }
+
+            buffer.Add(LogLine.FromText(evt.Data));
 
             var elapsed = Environment.TickCount64 - lastFlush;
             if (buffer.Count < maxBatchSize && elapsed < 100)
@@ -198,8 +205,19 @@ public partial class JobDetailViewModel : ReactiveObject, IDisposable
 
         var updated = await _client.GetJobAsync(Job.Id);
         if (updated is not null)
-            Avalonia.Threading.Dispatcher.UIThread.Post(() => StatusText = updated.Status.ToString());
+            Avalonia.Threading.Dispatcher.UIThread.Post(() => StatusText = FormatStatus(updated.Status));
     }
+
+    private static string FormatStatus(JobStatus status) => status switch
+    {
+        JobStatus.Queued => "⏳ Queued — Waiting for worker",
+        JobStatus.Assigned => "🔄 Assigned",
+        JobStatus.Running => "🚀 Running",
+        JobStatus.Succeeded => "✅ Succeeded",
+        JobStatus.Failed => "❌ Failed",
+        JobStatus.Cancelled => "🚫 Cancelled",
+        _ => status.ToString()
+    };
 
     private void FeedBatchToTerminal(List<LogLine> batch)
     {


### PR DESCRIPTION
## Problem

When a job is enqueued and no worker is available (or the worker is slow to come online), the GUI shows a static "Queued" label with a blank terminal — zero feedback. The user has no idea whether the system is working or stuck.

Additionally, the worker's initial "I'm Online" announcement to the coordinator was fire-and-forget — if it failed (e.g. coordinator still starting), the worker silently remained Offline until the next heartbeat (30s later).

## Changes

### SSE status events (Coordinator → GUI)
- **`JobEndpoints.StreamLogs`**: Now sends `event: status` SSE named events on job status transitions. Polls job status every 5s (down from 15s keep-alive) while waiting for a worker. Sends synthetic log lines for human-readable feedback:
  - `⏳ Waiting for an available worker…` (Queued)
  - `🔄 Worker assigned, preparing deployment…` (Assigned)
  - `🚀 Deployment started` (Running)
- Breaks out of streaming loop when job reaches terminal state while waiting

### API Client
- **`FleetApiClient`**: New `StreamJobEventsAsync` method that parses SSE `event:` lines and yields typed `SseEvent(Type, Data)` records. `StreamJobLogsAsync` preserved as a convenience wrapper.

### GUI
- **`JobDetailViewModel`**: Switches to `StreamJobEventsAsync`, updates `StatusText` live with emoji-prefixed human-readable labels (e.g. "⏳ Queued — Waiting for worker", "🚀 Running", "✅ Succeeded")

### Worker robustness
- **`RemoteWorkerBackgroundService`**: Retries initial Online announcement up to 5 times with exponential backoff (2s, 4s, 6s, 8s, 10s) instead of silently swallowing failure

## Testing
- All 51 existing tests pass
- 0 build errors, 13 pre-existing warnings