### PR TITLE
fix: prevent ValueTask double-consume in SSE streaming loop

### DIFF
--- a/src/DotnetFleet.Coordinator/Endpoints/JobEndpoints.cs
+++ b/src/DotnetFleet.Coordinator/Endpoints/JobEndpoints.cs
@@ -91,18 +91,19 @@ public static class JobEndpoints
             // Stream new log lines as they arrive, polling job status on each heartbeat
             // so the client gets timely feedback during the Queued→Running transition.
             var statusPollInterval = TimeSpan.FromSeconds(5);
-            ValueTask<string> pendingRead = channel.Reader.ReadAsync(ct);
+            // Convert ValueTask to Task exactly once per ReadAsync call.
+            // ValueTask must never be awaited / AsTask'd more than once.
+            var pendingRead = channel.Reader.ReadAsync(ct).AsTask();
             while (!ct.IsCancellationRequested)
             {
-                var readTask = pendingRead.AsTask();
                 var delayTask = Task.Delay(statusPollInterval, ct);
-                var winner = await Task.WhenAny(readTask, delayTask);
+                var winner = await Task.WhenAny(pendingRead, delayTask);
 
-                if (winner == readTask)
+                if (winner == pendingRead)
                 {
-                    var line = await readTask;
+                    var line = await pendingRead;
                     await WriteEventAsync(httpContext.Response, line, ct);
-                    pendingRead = channel.Reader.ReadAsync(ct);
+                    pendingRead = channel.Reader.ReadAsync(ct).AsTask();
                 }
                 else
                 {


### PR DESCRIPTION
## Problem

The SSE log-streaming endpoint crashed after exactly 5 seconds (the first heartbeat interval) with:

```
System.InvalidOperationException: Another continuation was already registered.
   at System.Threading.Channels.AsyncOperation.ThrowMultipleContinuations()
```

This caused the GUI to stay stuck on **"⏳ Queued — Waiting for worker"** even though the worker had claimed and was actively executing the job. No log lines were streamed after the initial synthetic message.

## Root cause

The streaming loop stored a `ValueTask<string>` from `channel.Reader.ReadAsync()` and called `.AsTask()` on it **every iteration**. Per the .NET docs, a `ValueTask` must only be consumed once — calling `AsTask()` a second time on the same instance throws `InvalidOperationException`.

On the first iteration, `AsTask()` succeeded. On the second iteration (after the 5s delay won the `WhenAny` race), `AsTask()` was called again on the same `ValueTask`, crashing the endpoint.

## Fix

Convert `ValueTask` → `Task` exactly once per `ReadAsync()` call and reuse the resulting `Task` reference across loop iterations until a log line is consumed.

## Verified

- 51 tests pass
- Full e2e test: coordinator + worker + GUI
- SSE stream stayed open for full job duration (~15s vs 5s before)
- Status transitions (Queued → Running → Failed) reflected live in GUI
- Log lines streamed in real-time