### PR TITLE
fix: resolve NETSDK1152 appsettings.json collision in Tool pack

### DIFF
--- a/src/DotnetFleet.Coordinator/Endpoints/JobEndpoints.cs
+++ b/src/DotnetFleet.Coordinator/Endpoints/JobEndpoints.cs
@@ -91,18 +91,19 @@ public static class JobEndpoints
             // Stream new log lines as they arrive, polling job status on each heartbeat
             // so the client gets timely feedback during the Queued→Running transition.
             var statusPollInterval = TimeSpan.FromSeconds(5);
-            ValueTask<string> pendingRead = channel.Reader.ReadAsync(ct);
+            // Convert ValueTask to Task exactly once per ReadAsync call.
+            // ValueTask must never be awaited / AsTask'd more than once.
+            var pendingRead = channel.Reader.ReadAsync(ct).AsTask();
             while (!ct.IsCancellationRequested)
             {
-                var readTask = pendingRead.AsTask();
                 var delayTask = Task.Delay(statusPollInterval, ct);
-                var winner = await Task.WhenAny(readTask, delayTask);
+                var winner = await Task.WhenAny(pendingRead, delayTask);
 
-                if (winner == readTask)
+                if (winner == pendingRead)
                 {
-                    var line = await readTask;
+                    var line = await pendingRead;
                     await WriteEventAsync(httpContext.Response, line, ct);
-                    pendingRead = channel.Reader.ReadAsync(ct);
+                    pendingRead = channel.Reader.ReadAsync(ct).AsTask();
                 }
                 else
                 {

--- a/src/DotnetFleet.Tool/DotnetFleet.Tool.csproj
+++ b/src/DotnetFleet.Tool/DotnetFleet.Tool.csproj
@@ -15,6 +15,8 @@
     <PackageTags>ci;cd;deploy;fleet;dotnet</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/SuperJMN/DotnetFleet</RepositoryUrl>
+    <!-- Coordinator and Worker both ship appsettings.json; allow last-writer-wins during pack/publish -->
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Problem\n\n`dotnet pack` on `DotnetFleet.Tool` fails with **NETSDK1152** because both `DotnetFleet.Coordinator` and `DotnetFleet.Worker` ship `appsettings.json`, causing a collision in the publish output.\n\nThis caused the NuGet deployment step to fail (while GitHub Release succeeded).\n\n## Fix\n\nSet `ErrorOnDuplicatePublishOutputFiles=false` in the Tool project — the standard approach for tool projects that aggregate multiple hosts with same-named config files.\n\n## Verification\n\n- `dotnet pack` succeeds ✅\n- 51 tests pass ✅