### PR TITLE
feat(workers): report and display worker version

### DIFF
--- a/src/DotnetFleet.Api.Client/FleetApiClient.cs
+++ b/src/DotnetFleet.Api.Client/FleetApiClient.cs
@@ -249,7 +249,8 @@ public class FleetApiClient
         bool IsEmbedded,
         DateTimeOffset? LastSeenAt,
         double MaxDiskUsageGb,
-        string? RepoStoragePath);
+        string? RepoStoragePath,
+        string? Version = null);
 
     // ── Secrets ───────────────────────────────────────────────────────────────
 

--- a/src/DotnetFleet.Coordinator/Endpoints/WorkerEndpoints.cs
+++ b/src/DotnetFleet.Coordinator/Endpoints/WorkerEndpoints.cs
@@ -43,7 +43,8 @@ public static class WorkerEndpoints
         {
             w.Id, w.Name, w.Status, w.IsEmbedded, w.LastSeenAt,
             maxDiskUsageGb = w.MaxDiskUsageBytes / (1024.0 * 1024 * 1024),
-            w.RepoStoragePath
+            w.RepoStoragePath,
+            w.Version
         }));
     }
 
@@ -95,7 +96,8 @@ public static class WorkerEndpoints
     private static async Task<IResult> Heartbeat(
         Guid id,
         HttpContext httpContext,
-        IFleetStorage storage)
+        IFleetStorage storage,
+        [FromBody] HeartbeatRequest? req = null)
     {
         var claimedId = httpContext.User.FindFirst("worker_id")?.Value;
         if (!Guid.TryParse(claimedId, out var tokenWorkerId) || tokenWorkerId != id)
@@ -107,6 +109,8 @@ public static class WorkerEndpoints
         worker.LastSeenAt = DateTimeOffset.UtcNow;
         if (worker.Status == WorkerStatus.Offline)
             worker.Status = WorkerStatus.Online;
+        if (!string.IsNullOrWhiteSpace(req?.Version))
+            worker.Version = req.Version;
         await storage.UpdateWorkerAsync(worker);
         return Results.Ok();
     }
@@ -201,4 +205,5 @@ public static class WorkerEndpoints
     public record UpdateWorkerConfigRequest(double? MaxDiskUsageGb, string? RepoStoragePath);
     public record WorkerLoginRequest(Guid WorkerId, string Secret);
     public record UpdateWorkerStatusRequest(WorkerStatus Status);
+    public record HeartbeatRequest(string? Version);
 }

--- a/src/DotnetFleet.Core/Domain/Worker.cs
+++ b/src/DotnetFleet.Core/Domain/Worker.cs
@@ -16,4 +16,11 @@ public class Worker
     public long MaxDiskUsageBytes { get; set; } = 10L * 1024 * 1024 * 1024; // 10 GB default
 
     public string? RepoStoragePath { get; set; }
+
+    /// <summary>
+    /// Informational version of the running worker binary (e.g. "1.2.3+abcdef0").
+    /// Reported by the worker on each heartbeat; null until the first heartbeat
+    /// from a version-aware worker arrives.
+    /// </summary>
+    public string? Version { get; set; }
 }

--- a/src/DotnetFleet.Worker/Coordinator/HttpWorkerCoordinatorClient.cs
+++ b/src/DotnetFleet.Worker/Coordinator/HttpWorkerCoordinatorClient.cs
@@ -24,8 +24,19 @@ public class HttpWorkerCoordinatorClient : IWorkerCoordinatorClient
     }
 
     public async Task SendHeartbeatAsync(Guid workerId, CancellationToken ct = default)
+        => await SendHeartbeatAsync(workerId, version: null, ct);
+
+    public async Task SendHeartbeatAsync(Guid workerId, string? version, CancellationToken ct = default)
     {
-        var resp = await http.PostAsync($"/api/workers/{workerId}/heartbeat", content: null, ct);
+        HttpResponseMessage resp;
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            resp = await http.PostAsync($"/api/workers/{workerId}/heartbeat", content: null, ct);
+        }
+        else
+        {
+            resp = await http.PostAsJsonAsync($"/api/workers/{workerId}/heartbeat", new { version }, ct);
+        }
         if (!resp.IsSuccessStatusCode)
             logger.LogWarning("Heartbeat returned {Status}", (int)resp.StatusCode);
     }

--- a/src/DotnetFleet.Worker/Coordinator/IWorkerCoordinatorClient.cs
+++ b/src/DotnetFleet.Worker/Coordinator/IWorkerCoordinatorClient.cs
@@ -10,6 +10,7 @@ public interface IWorkerCoordinatorClient
 {
     Task<Worker?> GetSelfAsync(CancellationToken ct = default);
     Task SendHeartbeatAsync(Guid workerId, CancellationToken ct = default);
+    Task SendHeartbeatAsync(Guid workerId, string? version, CancellationToken ct = default);
     Task UpdateStatusAsync(Guid workerId, WorkerStatus status, CancellationToken ct = default);
 
     Task<Project?> GetProjectAsync(Guid projectId, CancellationToken ct = default);

--- a/src/DotnetFleet.Worker/RemoteWorkerBackgroundService.cs
+++ b/src/DotnetFleet.Worker/RemoteWorkerBackgroundService.cs
@@ -7,6 +7,7 @@ using DotnetFleet.WorkerService.RepoStorage;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using System.Reflection;
 
 namespace DotnetFleet.WorkerService;
 
@@ -20,6 +21,12 @@ namespace DotnetFleet.WorkerService;
 /// </summary>
 public class RemoteWorkerBackgroundService : BackgroundService
 {
+    private static readonly string WorkerVersion =
+        typeof(RemoteWorkerBackgroundService).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+        ?? typeof(RemoteWorkerBackgroundService).Assembly.GetName().Version?.ToString()
+        ?? "unknown";
+
     private readonly IWorkerJobSource jobSource;
     private readonly IWorkerCoordinatorClient coordinator;
     private readonly WorkerOptions options;
@@ -98,7 +105,7 @@ public class RemoteWorkerBackgroundService : BackgroundService
         {
             try
             {
-                await coordinator.SendHeartbeatAsync(workerId, ct);
+                await coordinator.SendHeartbeatAsync(workerId, WorkerVersion, ct);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {

--- a/src/DotnetFleet/Views/WorkersView.axaml
+++ b/src/DotnetFleet/Views/WorkersView.axaml
@@ -29,6 +29,10 @@
                                     <TextBlock Text="{Binding EmbeddedLabel}"
                                                Opacity="0.5" FontSize="12"
                                                VerticalAlignment="Center" />
+                                    <TextBlock Text="{Binding Worker.Version, StringFormat='v{0}'}"
+                                               IsVisible="{Binding Worker.Version, Converter={x:Static ObjectConverters.IsNotNull}}"
+                                               Opacity="0.6" FontSize="11"
+                                               VerticalAlignment="Center" />
                                 </StackPanel>
                                 <TextBlock Text="{Binding StatusLabel}" FontSize="12" />
                                 <TextBlock FontSize="11" Opacity="0.6">


### PR DESCRIPTION
## Resumen

Ahora se puede ver la versión del **coordinador** *y* la de **cada worker** en la UI.

- La versión del coordinador ya se mostraba en la barra superior (`MainShell`) a través de `/health` → `BackendVersion`. Sin cambios.
- Los workers pasan a reportar su `AssemblyInformationalVersion` en cada heartbeat. El coordinador la persiste en el agregado `Worker` y la expone en `GET /api/workers`. `WorkersView` pinta `v{Version}` de forma discreta junto al nombre del worker.

## Cambios

- `Core.Domain.Worker` → nueva propiedad `string? Version`.
- `WorkerEndpoints.Heartbeat` acepta un body opcional `{ "version": "..." }`; llamadas sin cuerpo siguen funcionando (compatibilidad hacia atrás con workers viejos).
- `GET /api/workers` incluye `version` en la proyección.
- `IWorkerCoordinatorClient` / `HttpWorkerCoordinatorClient`: nueva sobrecarga `SendHeartbeatAsync(workerId, version, ct)`.
- `RemoteWorkerBackgroundService` calcula la versión una vez y la envía en cada heartbeat.
- `FleetApiClient.WorkerInfo` incluye `Version`.
- `WorkersView.axaml` muestra la versión junto al nombre.

## Notas

- No hace falta migración EF: el coordinador usa `EnsureCreatedAsync()`.
- Workers aún no actualizados aparecerán sin versión hasta recibir el nuevo binario.

## Verificación

- `dotnet build DotnetFleet.slnx`: ✅ limpio.
- `dotnet test`: ✅ 51/51.