### PR TITLE
fix(ui): brighten log level colors for dark background (#13)

### DIFF
--- a/src/DotnetFleet/Views/Logging/LogAnsi.cs
+++ b/src/DotnetFleet/Views/Logging/LogAnsi.cs
@@ -17,12 +17,12 @@ internal static class LogAnsi
 
     private static string? GetAnsiCode(LogSeverity severity) => severity switch
     {
-        LogSeverity.Trace   => "\x1b[90m",        // bright black (gray)
-        LogSeverity.Debug   => "\x1b[37m",         // white (dim)
-        LogSeverity.Info    => "\x1b[34m",          // blue
-        LogSeverity.Warning => "\x1b[33m",          // yellow
-        LogSeverity.Error   => "\x1b[1;31m",        // bold red
-        LogSeverity.Fatal   => "\x1b[1;91m",        // bold bright red
+        LogSeverity.Trace   => "\x1b[37m",          // light gray
+        LogSeverity.Debug   => "\x1b[94m",          // bright blue
+        LogSeverity.Info    => "\x1b[97m",          // bright white
+        LogSeverity.Warning => "\x1b[93m",          // bright yellow/amber
+        LogSeverity.Error   => "\x1b[1;91m",        // bold bright red
+        LogSeverity.Fatal   => "\x1b[1;91m",        // bold bright red (intense)
         _                   => null
     };
 }

--- a/src/DotnetFleet/Views/Logging/LogTextPresenter.cs
+++ b/src/DotnetFleet/Views/Logging/LogTextPresenter.cs
@@ -176,14 +176,14 @@ public static class LogTextPresenter
 
 internal static class SeverityColors
 {
-    // Theme-friendly explicit colours; chosen to be readable on both light and dark backgrounds.
-    public static readonly IBrush Default = new SolidColorBrush(Color.FromRgb(0xCC, 0xCC, 0xCC));
-    public static readonly IBrush Trace   = new SolidColorBrush(Color.FromRgb(0x88, 0x88, 0x88));
-    public static readonly IBrush Debug   = new SolidColorBrush(Color.FromRgb(0x9C, 0xA3, 0xAF));
-    public static readonly IBrush Info    = new SolidColorBrush(Color.FromRgb(0x60, 0xA5, 0xFA));
-    public static readonly IBrush Warning = new SolidColorBrush(Color.FromRgb(0xF5, 0x9E, 0x0B));
-    public static readonly IBrush Error   = new SolidColorBrush(Color.FromRgb(0xEF, 0x44, 0x44));
-    public static readonly IBrush Fatal   = new SolidColorBrush(Color.FromRgb(0xDC, 0x26, 0x26));
+    // Bright, high-contrast colours chosen for readability on a dark/black terminal background.
+    public static readonly IBrush Default = new SolidColorBrush(Color.FromRgb(0xDC, 0xDC, 0xDC));
+    public static readonly IBrush Trace   = new SolidColorBrush(Color.FromRgb(0xB0, 0xB0, 0xB0));
+    public static readonly IBrush Debug   = new SolidColorBrush(Color.FromRgb(0x6F, 0xB8, 0xFF));
+    public static readonly IBrush Info    = new SolidColorBrush(Color.FromRgb(0xFF, 0xFF, 0xFF));
+    public static readonly IBrush Warning = new SolidColorBrush(Color.FromRgb(0xFF, 0xD2, 0x4D));
+    public static readonly IBrush Error   = new SolidColorBrush(Color.FromRgb(0xFF, 0x6B, 0x6B));
+    public static readonly IBrush Fatal   = new SolidColorBrush(Color.FromRgb(0xFF, 0x3B, 0x3B));
 
     public static readonly IBrush MatchHighlight = new SolidColorBrush(Color.FromArgb(0x80, 0xFA, 0xCC, 0x15));
 


### PR DESCRIPTION
Fixes #13.

Log lines on the dark terminal/log background were too dim to read. This bumps the per-severity foreground brushes (and matching ANSI codes for the terminal log viewer) to a bright, high-contrast palette suitable for a black background.

### Before → After (RGB)
| Severity | Before | After |
| --- | --- | --- |
| Default | #CCCCCC | #DCDCDC |
| Trace | #888888 | #B0B0B0 |
| Debug | #9CA3AF | #6FB8FF |
| Info | #60A5FA | #FFFFFF |
| Warning | #F59E0B | #FFD24D |
| Error | #EF4444 | #FF6B6B |
| Fatal | #DC2626 | #FF3B3B |

ANSI codes used by the AvaloniaTerminal log viewer were updated to their bright variants (\x1b[9xm) and `Info` switched from blue to bright white for legibility on black.

### Files
- `src/DotnetFleet/Views/Logging/LogTextPresenter.cs` (`SeverityColors`)
- `src/DotnetFleet/Views/Logging/LogAnsi.cs`

### Tests
Pure visual constants — no logic added. The existing test project does not reference the Avalonia UI assembly, so no unit tests were added (matches the task brief: "pure axaml/resource-only changes don't strictly need tests"). Build succeeds; pre-existing `StaleJobReaperTests` timestamp-precision failure on `master` is unrelated.

Closes #13