### PR TITLE
feat(coordinator): capability-aware worker selection (#14)

### DIFF
--- a/src/DotnetFleet.Api.Client/FleetApiClient.cs
+++ b/src/DotnetFleet.Api.Client/FleetApiClient.cs
@@ -250,7 +250,12 @@ public class FleetApiClient
         DateTimeOffset? LastSeenAt,
         double MaxDiskUsageGb,
         string? RepoStoragePath,
-        string? Version = null);
+        string? Version = null,
+        int ProcessorCount = 0,
+        long TotalMemoryMb = 0,
+        string? OperatingSystem = null,
+        string? Architecture = null,
+        string? CpuModel = null);
 
     // ── Secrets ───────────────────────────────────────────────────────────────
 

--- a/src/DotnetFleet.Coordinator/CoordinatorHostBuilder.cs
+++ b/src/DotnetFleet.Coordinator/CoordinatorHostBuilder.cs
@@ -45,6 +45,7 @@ public static class CoordinatorHostBuilder
                           ?? "Data Source=fleet.db"));
 
         builder.Services.AddSingleton<IFleetStorage, EfFleetStorage>();
+        builder.Services.AddSingleton<IWorkerSelector, CapabilityWorkerSelector>();
 
         // ── Auth ─────────────────────────────────────────────────────────────
         builder.Services.AddSingleton<JwtService>();
@@ -162,6 +163,15 @@ public static class CoordinatorHostBuilder
             await db.Database.ExecuteSqlRawAsync("ALTER TABLE \"Workers\" ADD COLUMN \"Version\" TEXT NULL");
         }
 
+        // Capability columns (issue #14): added so the coordinator can pick the
+        // best-suited worker for each job. Each ALTER is gated by a pragma_table_info
+        // probe so re-runs and pre-existing databases stay safe.
+        await EnsureWorkerColumnAsync(db, "ProcessorCount", "INTEGER NOT NULL DEFAULT 0");
+        await EnsureWorkerColumnAsync(db, "TotalMemoryMb", "INTEGER NOT NULL DEFAULT 0");
+        await EnsureWorkerColumnAsync(db, "OperatingSystem", "TEXT NULL");
+        await EnsureWorkerColumnAsync(db, "Architecture", "TEXT NULL");
+        await EnsureWorkerColumnAsync(db, "CpuModel", "TEXT NULL");
+
         // ── Startup reconciliation ─────────────────────────────────────────
         // Jobs that were Running or Assigned during the last shutdown can never
         // complete because the worker context is lost. Fail them so they don't
@@ -205,6 +215,18 @@ public static class CoordinatorHostBuilder
             };
             await storage.AddUserAsync(admin);
             Log.Information("Seeded default admin user (username: admin)");
+        }
+    }
+
+    private static async Task EnsureWorkerColumnAsync(FleetDbContext db, string columnName, string columnDefinition)
+    {
+        var exists = (await db.Database
+            .SqlQueryRaw<long>($"SELECT COUNT(*) AS \"Value\" FROM pragma_table_info('Workers') WHERE name='{columnName}'")
+            .ToListAsync()).FirstOrDefault() > 0;
+        if (!exists)
+        {
+            await db.Database.ExecuteSqlRawAsync(
+                $"ALTER TABLE \"Workers\" ADD COLUMN \"{columnName}\" {columnDefinition}");
         }
     }
 

--- a/src/DotnetFleet.Coordinator/Data/EfFleetStorage.cs
+++ b/src/DotnetFleet.Coordinator/Data/EfFleetStorage.cs
@@ -9,7 +9,7 @@ namespace DotnetFleet.Coordinator.Data;
 /// operation creates its own short-lived DbContext — safe for concurrent
 /// singletons (BackgroundServices) and scoped API handlers alike.
 /// </summary>
-public class EfFleetStorage(IDbContextFactory<FleetDbContext> factory) : IFleetStorage
+public class EfFleetStorage(IDbContextFactory<FleetDbContext> factory, IWorkerSelector selector) : IFleetStorage
 {
     // Projects
     public async Task<IReadOnlyList<Project>> GetProjectsAsync(CancellationToken ct = default)
@@ -99,6 +99,29 @@ public class EfFleetStorage(IDbContextFactory<FleetDbContext> factory) : IFleetS
             .FirstOrDefaultAsync(ct);
 
         if (job is null)
+        {
+            await tx.CommitAsync(ct);
+            return null;
+        }
+
+        // Capability-aware selection: only let the caller claim if it is the best
+        // currently-idle worker (Online == idle here; Busy workers are running a job
+        // and Offline workers are out of the pool). When a beefier worker is also
+        // idle, return null and let it claim on its own next poll.
+        // The caller is always treated as a candidate (even if its DB row is still
+        // Offline or absent) so a freshly-online or unregistered worker can still
+        // claim when it is the only contender — preserving backward compatibility
+        // with workers that don't yet report capabilities.
+        var idleOthers = await db.Workers
+            .Where(w => w.Status == WorkerStatus.Online && w.Id != workerId)
+            .ToListAsync(ct);
+
+        var callerRow = await db.Workers.FirstOrDefaultAsync(w => w.Id == workerId, ct);
+        var callerCandidate = callerRow ?? new Worker { Id = workerId };
+
+        var candidates = idleOthers.Append(callerCandidate);
+        var best = selector.SelectBest(candidates);
+        if (best is null || best.Id != workerId)
         {
             await tx.CommitAsync(ct);
             return null;

--- a/src/DotnetFleet.Coordinator/Endpoints/WorkerEndpoints.cs
+++ b/src/DotnetFleet.Coordinator/Endpoints/WorkerEndpoints.cs
@@ -46,7 +46,12 @@ public static class WorkerEndpoints
             w.Id, w.Name, w.Status, w.IsEmbedded, w.LastSeenAt,
             maxDiskUsageGb = w.MaxDiskUsageBytes / (1024.0 * 1024 * 1024),
             w.RepoStoragePath,
-            w.Version
+            w.Version,
+            w.ProcessorCount,
+            w.TotalMemoryMb,
+            w.OperatingSystem,
+            w.Architecture,
+            w.CpuModel
         }));
     }
 
@@ -74,7 +79,12 @@ public static class WorkerEndpoints
             MaxDiskUsageBytes = req.MaxDiskUsageGb.HasValue
                 ? (long)(req.MaxDiskUsageGb.Value * 1024 * 1024 * 1024)
                 : 10L * 1024 * 1024 * 1024,
-            RepoStoragePath = req.RepoStoragePath
+            RepoStoragePath = req.RepoStoragePath,
+            ProcessorCount = req.ProcessorCount ?? 0,
+            TotalMemoryMb = req.TotalMemoryMb ?? 0,
+            OperatingSystem = req.OperatingSystem,
+            Architecture = req.Architecture,
+            CpuModel = req.CpuModel
         };
 
         await storage.AddWorkerAsync(worker);
@@ -113,6 +123,16 @@ public static class WorkerEndpoints
             worker.Status = WorkerStatus.Online;
         if (!string.IsNullOrWhiteSpace(req?.Version))
             worker.Version = req.Version;
+        if (req?.ProcessorCount is { } cpuCount && cpuCount > 0)
+            worker.ProcessorCount = cpuCount;
+        if (req?.TotalMemoryMb is { } memMb && memMb > 0)
+            worker.TotalMemoryMb = memMb;
+        if (!string.IsNullOrWhiteSpace(req?.OperatingSystem))
+            worker.OperatingSystem = req.OperatingSystem;
+        if (!string.IsNullOrWhiteSpace(req?.Architecture))
+            worker.Architecture = req.Architecture;
+        if (!string.IsNullOrWhiteSpace(req?.CpuModel))
+            worker.CpuModel = req.CpuModel;
         await storage.UpdateWorkerAsync(worker);
         return Results.Ok();
     }
@@ -219,9 +239,24 @@ public static class WorkerEndpoints
         return Guid.TryParse(raw, out workerId);
     }
 
-    public record RegisterWorkerRequest(string Name, bool IsEmbedded = false, double? MaxDiskUsageGb = null, string? RepoStoragePath = null);
+    public record RegisterWorkerRequest(
+        string Name,
+        bool IsEmbedded = false,
+        double? MaxDiskUsageGb = null,
+        string? RepoStoragePath = null,
+        int? ProcessorCount = null,
+        long? TotalMemoryMb = null,
+        string? OperatingSystem = null,
+        string? Architecture = null,
+        string? CpuModel = null);
     public record UpdateWorkerConfigRequest(double? MaxDiskUsageGb, string? RepoStoragePath);
     public record WorkerLoginRequest(Guid WorkerId, string Secret);
     public record UpdateWorkerStatusRequest(WorkerStatus Status);
-    public record HeartbeatRequest(string? Version);
+    public record HeartbeatRequest(
+        string? Version,
+        int? ProcessorCount = null,
+        long? TotalMemoryMb = null,
+        string? OperatingSystem = null,
+        string? Architecture = null,
+        string? CpuModel = null);
 }

--- a/src/DotnetFleet.Core/Domain/CapabilityWorkerSelector.cs
+++ b/src/DotnetFleet.Core/Domain/CapabilityWorkerSelector.cs
@@ -1,0 +1,45 @@
+using DotnetFleet.Core.Interfaces;
+
+namespace DotnetFleet.Core.Domain;
+
+/// <summary>
+/// Default capability-aware <see cref="IWorkerSelector"/>. Scores a worker by combining
+/// CPU cores, RAM and a small bonus for desktop-class architectures so that, given a
+/// choice, beefier hardware always wins. The formula is intentionally simple and
+/// deterministic — it minimizes deployment time on heterogeneous fleets (e.g. RPi vs PC)
+/// without needing per-worker benchmarks.
+/// </summary>
+/// <remarks>
+/// Score formula: <c>cores * 10 + (memoryMb / 1024) * 5 + archBonus</c>.
+/// <list type="bullet">
+///   <item>Arch bonus: x64 = 3, arm64 = 1, arm/unknown = 0.</item>
+///   <item>Workers with 0 cores AND 0 memory (legacy / not yet reported) score 0.</item>
+///   <item>Tiebreak: <see cref="Worker.Name"/> ordinal, then <see cref="Worker.Id"/>.</item>
+/// </list>
+/// </remarks>
+public class CapabilityWorkerSelector : IWorkerSelector
+{
+    public int Score(Worker worker)
+    {
+        var cores = Math.Max(0, worker.ProcessorCount);
+        var memoryGb = (int)(Math.Max(0, worker.TotalMemoryMb) / 1024);
+        var archBonus = (worker.Architecture ?? string.Empty).Trim().ToLowerInvariant() switch
+        {
+            "x64" or "amd64" => 3,
+            "arm64" or "aarch64" => 1,
+            _ => 0
+        };
+        return cores * 10 + memoryGb * 5 + archBonus;
+    }
+
+    public Worker? SelectBest(IEnumerable<Worker> candidates)
+    {
+        ArgumentNullException.ThrowIfNull(candidates);
+
+        return candidates
+            .OrderByDescending(Score)
+            .ThenBy(w => w.Name, StringComparer.Ordinal)
+            .ThenBy(w => w.Id)
+            .FirstOrDefault();
+    }
+}

--- a/src/DotnetFleet.Core/Domain/Worker.cs
+++ b/src/DotnetFleet.Core/Domain/Worker.cs
@@ -23,4 +23,24 @@ public class Worker
     /// from a version-aware worker arrives.
     /// </summary>
     public string? Version { get; set; }
+
+    // ── Hardware capabilities (reported by the worker at register/heartbeat) ──
+    // All values default to 0 / null so legacy workers that don't report them
+    // still round-trip safely. The capability-aware selector treats missing
+    // values as the least-preferred score.
+
+    /// <summary>Number of logical CPUs reported by <c>Environment.ProcessorCount</c>.</summary>
+    public int ProcessorCount { get; set; }
+
+    /// <summary>Total physical RAM in megabytes (best-effort, reported by the worker).</summary>
+    public long TotalMemoryMb { get; set; }
+
+    /// <summary>Operating system family (e.g. "Linux", "Windows", "OSX").</summary>
+    public string? OperatingSystem { get; set; }
+
+    /// <summary>Process architecture (e.g. "X64", "Arm64", "Arm").</summary>
+    public string? Architecture { get; set; }
+
+    /// <summary>Optional human-readable CPU model name.</summary>
+    public string? CpuModel { get; set; }
 }

--- a/src/DotnetFleet.Core/Interfaces/IWorkerSelector.cs
+++ b/src/DotnetFleet.Core/Interfaces/IWorkerSelector.cs
@@ -1,0 +1,25 @@
+using DotnetFleet.Core.Domain;
+
+namespace DotnetFleet.Core.Interfaces;
+
+/// <summary>
+/// Strategy that picks the best worker to receive a new deployment from a set of
+/// idle candidates. Implementations must be deterministic and side-effect free so
+/// that selection can be safely replayed during tests and concurrent claims.
+/// </summary>
+public interface IWorkerSelector
+{
+    /// <summary>
+    /// Computes a numeric capability score for <paramref name="worker"/>. Higher is better.
+    /// Workers with no reported capabilities (legacy) score 0 so they still get picked
+    /// when they are the only candidate, but lose to any worker that reports specs.
+    /// </summary>
+    int Score(Worker worker);
+
+    /// <summary>
+    /// Returns the best candidate from <paramref name="candidates"/> (highest score,
+    /// ties broken deterministically by <see cref="Worker.Name"/> then <see cref="Worker.Id"/>),
+    /// or <c>null</c> if the sequence is empty.
+    /// </summary>
+    Worker? SelectBest(IEnumerable<Worker> candidates);
+}

--- a/src/DotnetFleet.Worker/Bootstrap/WorkerBootstrap.cs
+++ b/src/DotnetFleet.Worker/Bootstrap/WorkerBootstrap.cs
@@ -63,6 +63,7 @@ public static class WorkerBootstrap
         http.DefaultRequestHeaders.Add("X-Registration-Token", options.RegistrationToken);
 
         var name = options.Name ?? Environment.MachineName;
+        var caps = WorkerCapabilityProbe.Detect();
         var body = new
         {
             name,
@@ -70,7 +71,12 @@ public static class WorkerBootstrap
             maxDiskUsageGb = options.MaxDiskUsageBytes.HasValue
                 ? options.MaxDiskUsageBytes.Value / (1024.0 * 1024 * 1024)
                 : (double?)null,
-            repoStoragePath = options.RepoStoragePath
+            repoStoragePath = options.RepoStoragePath,
+            processorCount = caps.ProcessorCount,
+            totalMemoryMb = caps.TotalMemoryMb,
+            operatingSystem = caps.OperatingSystem,
+            architecture = caps.Architecture,
+            cpuModel = caps.CpuModel
         };
 
         var resp = await http.PostAsJsonAsync("/api/workers/register", body, ct);

--- a/src/DotnetFleet.Worker/Bootstrap/WorkerCapabilityProbe.cs
+++ b/src/DotnetFleet.Worker/Bootstrap/WorkerCapabilityProbe.cs
@@ -1,0 +1,50 @@
+using System.Runtime.InteropServices;
+
+namespace DotnetFleet.WorkerService.Bootstrap;
+
+/// <summary>
+/// Reports the host machine's hardware capabilities to the coordinator so that the
+/// capability-aware worker selector can score this worker against its peers.
+/// All values are best-effort: when a metric can't be determined the corresponding
+/// field is left at its default (0 / null), which the coordinator interprets as
+/// "least preferred but still selectable".
+/// </summary>
+public static class WorkerCapabilityProbe
+{
+    public record Capabilities(
+        int ProcessorCount,
+        long TotalMemoryMb,
+        string OperatingSystem,
+        string Architecture,
+        string? CpuModel);
+
+    public static Capabilities Detect()
+    {
+        var os = OperatingSystem.IsWindows() ? "Windows"
+            : OperatingSystem.IsLinux() ? "Linux"
+            : OperatingSystem.IsMacOS() ? "OSX"
+            : RuntimeInformation.OSDescription;
+
+        var arch = RuntimeInformation.OSArchitecture.ToString();
+
+        long memoryMb = 0;
+        try
+        {
+            var info = GC.GetGCMemoryInfo();
+            // TotalAvailableMemoryBytes reflects the container/host memory limit
+            // visible to the process — good enough as a coarse capacity signal.
+            memoryMb = Math.Max(0, info.TotalAvailableMemoryBytes / (1024 * 1024));
+        }
+        catch
+        {
+            memoryMb = 0;
+        }
+
+        return new Capabilities(
+            ProcessorCount: Environment.ProcessorCount,
+            TotalMemoryMb: memoryMb,
+            OperatingSystem: os,
+            Architecture: arch,
+            CpuModel: null);
+    }
+}

--- a/src/DotnetFleet.Worker/Coordinator/HttpWorkerCoordinatorClient.cs
+++ b/src/DotnetFleet.Worker/Coordinator/HttpWorkerCoordinatorClient.cs
@@ -42,9 +42,26 @@ public class HttpWorkerCoordinatorClient : IWorkerCoordinatorClient
         {
             HttpResponseMessage resp;
             if (string.IsNullOrWhiteSpace(version))
+            {
                 resp = await http.PostAsync($"/api/workers/{workerId}/heartbeat", content: null, cts.Token);
+            }
             else
-                resp = await http.PostAsJsonAsync($"/api/workers/{workerId}/heartbeat", new { version }, cts.Token);
+            {
+                // Piggyback the host capabilities on every heartbeat. They rarely change, but
+                // sending them on each heartbeat means a coordinator that loses its DB still
+                // converges to the right scoring within one heartbeat interval.
+                var caps = DotnetFleet.WorkerService.Bootstrap.WorkerCapabilityProbe.Detect();
+                var payload = new
+                {
+                    version,
+                    processorCount = caps.ProcessorCount,
+                    totalMemoryMb = caps.TotalMemoryMb,
+                    operatingSystem = caps.OperatingSystem,
+                    architecture = caps.Architecture,
+                    cpuModel = caps.CpuModel
+                };
+                resp = await http.PostAsJsonAsync($"/api/workers/{workerId}/heartbeat", payload, cts.Token);
+            }
 
             if (!resp.IsSuccessStatusCode)
                 logger.LogWarning("Heartbeat returned {Status}", (int)resp.StatusCode);

--- a/src/DotnetFleet/ViewModels/WorkersViewModel.cs
+++ b/src/DotnetFleet/ViewModels/WorkersViewModel.cs
@@ -71,6 +71,25 @@ public partial class WorkerItemViewModel : ReactiveObject
 
     public string EmbeddedLabel => Worker.IsEmbedded ? "(embedded)" : string.Empty;
 
+    public string CapabilityLabel
+    {
+        get
+        {
+            if (Worker.ProcessorCount <= 0 && Worker.TotalMemoryMb <= 0)
+                return string.Empty;
+
+            var cores = Worker.ProcessorCount > 0 ? $"{Worker.ProcessorCount} core(s)" : null;
+            var memory = Worker.TotalMemoryMb > 0
+                ? $"{Worker.TotalMemoryMb / 1024.0:F1} GB"
+                : null;
+            var arch = !string.IsNullOrWhiteSpace(Worker.Architecture)
+                ? Worker.Architecture
+                : null;
+
+            return string.Join(" · ", new[] { cores, memory, arch }.Where(s => s is not null));
+        }
+    }
+
     private async Task SaveConfigAsync()
     {
         IsSaving = true;

--- a/tests/DotnetFleet.Tests/CapabilityClaimIntegrationTests.cs
+++ b/tests/DotnetFleet.Tests/CapabilityClaimIntegrationTests.cs
@@ -1,0 +1,137 @@
+using DotnetFleet.Coordinator.Data;
+using DotnetFleet.Core.Domain;
+using DotnetFleet.Core.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace DotnetFleet.Tests;
+
+/// <summary>
+/// End-to-end style integration test for the capability-aware claim path. Two workers
+/// register with different specs and both poll for a single queued job; only the
+/// higher-spec worker is allowed to claim it. The lower-spec worker may only claim
+/// after the better one becomes Busy/Offline (i.e. is no longer in the idle pool).
+/// </summary>
+public class CapabilityClaimIntegrationTests : IDisposable
+{
+    private readonly string dbPath;
+    private readonly IDbContextFactory<FleetDbContext> factory;
+    private readonly IWorkerSelector selector = new CapabilityWorkerSelector();
+
+    public CapabilityClaimIntegrationTests()
+    {
+        dbPath = Path.Combine(Path.GetTempPath(), $"fleet-cap-claim-{Guid.NewGuid():N}.db");
+        var options = new DbContextOptionsBuilder<FleetDbContext>()
+            .UseSqlite($"Data Source={dbPath}")
+            .Options;
+        factory = new InlineFactory(options);
+
+        using var db = factory.CreateDbContext();
+        db.Database.EnsureCreated();
+    }
+
+    private sealed class InlineFactory(DbContextOptions<FleetDbContext> options)
+        : IDbContextFactory<FleetDbContext>
+    {
+        public FleetDbContext CreateDbContext() => new(options);
+    }
+
+    public void Dispose()
+    {
+        try { File.Delete(dbPath); } catch { /* best-effort */ }
+    }
+
+    private async Task<DeploymentJob> SeedJobAsync(IFleetStorage storage)
+    {
+        var projectId = Guid.NewGuid();
+        await storage.AddProjectAsync(new Project
+        {
+            Id = projectId, Name = "p", GitUrl = "https://example.com/r.git", Branch = "main"
+        });
+        var job = new DeploymentJob
+        {
+            Id = Guid.NewGuid(), ProjectId = projectId,
+            Status = JobStatus.Queued, EnqueuedAt = DateTimeOffset.UtcNow
+        };
+        await storage.AddJobAsync(job);
+        return job;
+    }
+
+    [Fact]
+    public async Task High_spec_worker_wins_the_job_over_low_spec_worker()
+    {
+        var storage = new EfFleetStorage(factory, selector);
+
+        var rpi = new Worker
+        {
+            Name = "rpi4", Status = WorkerStatus.Online,
+            ProcessorCount = 4, TotalMemoryMb = 4 * 1024, Architecture = "Arm64"
+        };
+        var pc = new Worker
+        {
+            Name = "pc", Status = WorkerStatus.Online,
+            ProcessorCount = 8, TotalMemoryMb = 16 * 1024, Architecture = "X64"
+        };
+        await storage.AddWorkerAsync(rpi);
+        await storage.AddWorkerAsync(pc);
+
+        var job = await SeedJobAsync(storage);
+
+        // The lower-spec worker polls first — it must be told "no job for you" because
+        // a better worker is also idle. The job stays Queued.
+        var rpiClaim = await storage.ClaimNextJobAsync(rpi.Id);
+        rpiClaim.Should().BeNull("the higher-spec PC is idle and should preempt the RPi");
+
+        var stillQueued = await storage.GetJobAsync(job.Id);
+        stillQueued!.Status.Should().Be(JobStatus.Queued);
+        stillQueued.WorkerId.Should().BeNull();
+
+        // The PC polls next — it wins the job.
+        var pcClaim = await storage.ClaimNextJobAsync(pc.Id);
+        pcClaim.Should().NotBeNull();
+        pcClaim!.WorkerId.Should().Be(pc.Id);
+
+        var afterClaim = await storage.GetJobAsync(job.Id);
+        afterClaim!.Status.Should().Be(JobStatus.Assigned);
+        afterClaim.WorkerId.Should().Be(pc.Id);
+    }
+
+    [Fact]
+    public async Task Low_spec_worker_can_claim_when_high_spec_worker_is_busy()
+    {
+        var storage = new EfFleetStorage(factory, selector);
+
+        var rpi = new Worker
+        {
+            Name = "rpi4", Status = WorkerStatus.Online,
+            ProcessorCount = 4, TotalMemoryMb = 4 * 1024, Architecture = "Arm64"
+        };
+        var pc = new Worker
+        {
+            // Already running another job → Busy → not in the idle pool.
+            Name = "pc", Status = WorkerStatus.Busy,
+            ProcessorCount = 8, TotalMemoryMb = 16 * 1024, Architecture = "X64"
+        };
+        await storage.AddWorkerAsync(rpi);
+        await storage.AddWorkerAsync(pc);
+
+        await SeedJobAsync(storage);
+
+        var rpiClaim = await storage.ClaimNextJobAsync(rpi.Id);
+        rpiClaim.Should().NotBeNull("the only idle worker must be allowed to claim");
+        rpiClaim!.WorkerId.Should().Be(rpi.Id);
+    }
+
+    [Fact]
+    public async Task Single_idle_worker_claims_even_with_no_capabilities_reported()
+    {
+        var storage = new EfFleetStorage(factory, selector);
+
+        var legacy = new Worker { Name = "legacy", Status = WorkerStatus.Online };
+        await storage.AddWorkerAsync(legacy);
+        await SeedJobAsync(storage);
+
+        var claim = await storage.ClaimNextJobAsync(legacy.Id);
+        claim.Should().NotBeNull();
+        claim!.WorkerId.Should().Be(legacy.Id);
+    }
+}

--- a/tests/DotnetFleet.Tests/CapabilityWorkerSelectorTests.cs
+++ b/tests/DotnetFleet.Tests/CapabilityWorkerSelectorTests.cs
@@ -1,0 +1,121 @@
+using DotnetFleet.Core.Domain;
+using DotnetFleet.Core.Interfaces;
+
+namespace DotnetFleet.Tests;
+
+public class CapabilityWorkerSelectorTests
+{
+    private readonly IWorkerSelector selector = new CapabilityWorkerSelector();
+
+    private static Worker Make(
+        string name,
+        int cpu = 0,
+        long memMb = 0,
+        string? arch = null,
+        WorkerStatus status = WorkerStatus.Online,
+        Guid? id = null)
+        => new()
+        {
+            Id = id ?? Guid.NewGuid(),
+            Name = name,
+            ProcessorCount = cpu,
+            TotalMemoryMb = memMb,
+            Architecture = arch,
+            Status = status
+        };
+
+    [Fact]
+    public void Score_uses_cores_memory_and_architecture_bonus()
+    {
+        // 8 cores * 10 + (16384/1024) * 5 + 3 (x64) = 80 + 80 + 3 = 163
+        var pc = Make("pc", cpu: 8, memMb: 16 * 1024, arch: "X64");
+        selector.Score(pc).Should().Be(163);
+
+        // RPi4: 4 * 10 + (4096/1024) * 5 + 1 (arm64) = 40 + 20 + 1 = 61
+        var rpi = Make("rpi", cpu: 4, memMb: 4 * 1024, arch: "Arm64");
+        selector.Score(rpi).Should().Be(61);
+    }
+
+    [Fact]
+    public void Score_is_zero_for_worker_with_no_reported_capabilities()
+    {
+        selector.Score(Make("legacy")).Should().Be(0);
+    }
+
+    [Fact]
+    public void Score_treats_negative_values_as_zero()
+    {
+        var weird = Make("weird", cpu: -8, memMb: -1024, arch: "X64");
+        selector.Score(weird).Should().Be(3); // only the arch bonus survives
+    }
+
+    [Fact]
+    public void Score_arch_bonus_is_case_insensitive_and_handles_aliases()
+    {
+        selector.Score(Make("a", arch: "x64")).Should().Be(3);
+        selector.Score(Make("a", arch: "AMD64")).Should().Be(3);
+        selector.Score(Make("a", arch: "arm64")).Should().Be(1);
+        selector.Score(Make("a", arch: "AArch64")).Should().Be(1);
+        selector.Score(Make("a", arch: "Arm")).Should().Be(0);
+        selector.Score(Make("a", arch: null)).Should().Be(0);
+    }
+
+    [Fact]
+    public void SelectBest_picks_PC_over_RPi4()
+    {
+        var rpi = Make("rpi4", cpu: 4, memMb: 4 * 1024, arch: "Arm64");
+        var pc = Make("pc", cpu: 8, memMb: 16 * 1024, arch: "X64");
+
+        selector.SelectBest(new[] { rpi, pc })!.Name.Should().Be("pc");
+        selector.SelectBest(new[] { pc, rpi })!.Name.Should().Be("pc");
+    }
+
+    [Fact]
+    public void SelectBest_picks_high_spec_PC_over_low_spec_PC()
+    {
+        var low = Make("low", cpu: 2, memMb: 4 * 1024, arch: "X64");
+        var high = Make("high", cpu: 16, memMb: 64 * 1024, arch: "X64");
+
+        selector.SelectBest(new[] { low, high })!.Name.Should().Be("high");
+    }
+
+    [Fact]
+    public void SelectBest_breaks_ties_deterministically_by_name_then_id()
+    {
+        var idA = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        var idB = Guid.Parse("00000000-0000-0000-0000-000000000002");
+        var alpha = Make("beta", cpu: 4, memMb: 8 * 1024, arch: "X64", id: idA);
+        var beta = Make("alpha", cpu: 4, memMb: 8 * 1024, arch: "X64", id: idB);
+
+        // Same score, ordinal name compare → "alpha" wins regardless of input order.
+        selector.SelectBest(new[] { alpha, beta })!.Name.Should().Be("alpha");
+        selector.SelectBest(new[] { beta, alpha })!.Name.Should().Be("alpha");
+
+        // Same score and same name → smallest Id wins.
+        var twin1 = Make("twin", cpu: 4, memMb: 8 * 1024, arch: "X64", id: idA);
+        var twin2 = Make("twin", cpu: 4, memMb: 8 * 1024, arch: "X64", id: idB);
+        selector.SelectBest(new[] { twin2, twin1 })!.Id.Should().Be(idA);
+    }
+
+    [Fact]
+    public void SelectBest_returns_the_only_worker_when_alone()
+    {
+        var only = Make("solo", cpu: 4, memMb: 8 * 1024, arch: "X64");
+        selector.SelectBest(new[] { only })!.Id.Should().Be(only.Id);
+    }
+
+    [Fact]
+    public void SelectBest_returns_null_when_no_candidates()
+    {
+        selector.SelectBest(Array.Empty<Worker>()).Should().BeNull();
+    }
+
+    [Fact]
+    public void Worker_with_capabilities_beats_legacy_worker_without_them()
+    {
+        var legacy = Make("legacy");
+        var modern = Make("modern", cpu: 1, memMb: 1024, arch: "X64");
+
+        selector.SelectBest(new[] { legacy, modern })!.Name.Should().Be("modern");
+    }
+}

--- a/tests/DotnetFleet.Tests/DotnetFleet.Tests.csproj
+++ b/tests/DotnetFleet.Tests/DotnetFleet.Tests.csproj
@@ -18,5 +18,6 @@
     <ProjectReference Include="..\..\src\DotnetFleet.Coordinator\DotnetFleet.Coordinator.csproj" />
     <ProjectReference Include="..\..\src\DotnetFleet.Worker\DotnetFleet.Worker.csproj" />
     <ProjectReference Include="..\..\src\DotnetFleet.Tool\DotnetFleet.Tool.csproj" />
+    <ProjectReference Include="..\..\src\DotnetFleet\DotnetFleet.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/DotnetFleet.Tests/EfFleetStorageClaimRaceTests.cs
+++ b/tests/DotnetFleet.Tests/EfFleetStorageClaimRaceTests.cs
@@ -41,7 +41,7 @@ public class EfFleetStorageClaimRaceTests : IDisposable
     [Fact]
     public async Task Single_queued_job_is_claimed_by_exactly_one_worker_under_contention()
     {
-        var storage = new EfFleetStorage(factory);
+        var storage = new EfFleetStorage(factory, new CapabilityWorkerSelector());
         var projectId = Guid.NewGuid();
 
         await storage.AddProjectAsync(new Project
@@ -79,7 +79,7 @@ public class EfFleetStorageClaimRaceTests : IDisposable
     [Fact]
     public async Task ClaimNextJobAsync_returns_null_when_queue_is_empty()
     {
-        var storage = new EfFleetStorage(factory);
+        var storage = new EfFleetStorage(factory, new CapabilityWorkerSelector());
         var result = await storage.ClaimNextJobAsync(Guid.NewGuid());
         result.Should().BeNull();
     }

--- a/tests/DotnetFleet.Tests/FailJobsForWorkerTests.cs
+++ b/tests/DotnetFleet.Tests/FailJobsForWorkerTests.cs
@@ -41,7 +41,7 @@ public class FailJobsForWorkerTests : IDisposable
     [Fact]
     public async Task Fails_running_and_assigned_jobs_for_worker_and_leaves_terminal_ones_alone()
     {
-        var storage = new EfFleetStorage(factory);
+        var storage = new EfFleetStorage(factory, new CapabilityWorkerSelector());
         var projectId = Guid.NewGuid();
         var workerId = Guid.NewGuid();
         var otherWorkerId = Guid.NewGuid();
@@ -93,7 +93,7 @@ public class FailJobsForWorkerTests : IDisposable
     [Fact]
     public async Task Returns_empty_when_worker_has_no_live_jobs()
     {
-        var storage = new EfFleetStorage(factory);
+        var storage = new EfFleetStorage(factory, new CapabilityWorkerSelector());
         var workerId = Guid.NewGuid();
 
         var failed = await storage.FailJobsForWorkerAsync(workerId, "anything");

--- a/tests/DotnetFleet.Tests/StaleJobReaperTests.cs
+++ b/tests/DotnetFleet.Tests/StaleJobReaperTests.cs
@@ -39,7 +39,7 @@ public class StaleJobReaperTests : IDisposable
     [Fact]
     public async Task FailStuckAssignedJobsAsync_fails_assigned_jobs_past_timeout()
     {
-        var storage = new EfFleetStorage(factory);
+        var storage = new EfFleetStorage(factory, new CapabilityWorkerSelector());
         var projectId = Guid.NewGuid();
         var workerId = Guid.NewGuid();
 
@@ -87,7 +87,7 @@ public class StaleJobReaperTests : IDisposable
     [Fact]
     public async Task FailStuckAssignedJobsAsync_ignores_running_jobs()
     {
-        var storage = new EfFleetStorage(factory);
+        var storage = new EfFleetStorage(factory, new CapabilityWorkerSelector());
         var projectId = Guid.NewGuid();
 
         await storage.AddProjectAsync(new Project
@@ -114,7 +114,7 @@ public class StaleJobReaperTests : IDisposable
     [Fact]
     public async Task TouchWorkerAsync_updates_LastSeenAt_and_revives_offline_worker()
     {
-        var storage = new EfFleetStorage(factory);
+        var storage = new EfFleetStorage(factory, new CapabilityWorkerSelector());
         var workerId = Guid.NewGuid();
 
         await storage.AddWorkerAsync(new Worker
@@ -139,7 +139,7 @@ public class StaleJobReaperTests : IDisposable
     [Fact]
     public async Task TouchWorkerAsync_preserves_busy_status()
     {
-        var storage = new EfFleetStorage(factory);
+        var storage = new EfFleetStorage(factory, new CapabilityWorkerSelector());
         var workerId = Guid.NewGuid();
 
         await storage.AddWorkerAsync(new Worker
@@ -160,7 +160,7 @@ public class StaleJobReaperTests : IDisposable
     [Fact]
     public async Task TouchWorkerAsync_returns_false_for_unknown_worker()
     {
-        var storage = new EfFleetStorage(factory);
+        var storage = new EfFleetStorage(factory, new CapabilityWorkerSelector());
         var existed = await storage.TouchWorkerAsync(Guid.NewGuid());
         existed.Should().BeFalse();
     }

--- a/tests/DotnetFleet.Tests/WorkerItemViewModelTests.cs
+++ b/tests/DotnetFleet.Tests/WorkerItemViewModelTests.cs
@@ -1,0 +1,45 @@
+using DotnetFleet.Api.Client;
+using DotnetFleet.Core.Domain;
+using DotnetFleet.ViewModels;
+
+namespace DotnetFleet.Tests;
+
+public class WorkerItemViewModelTests
+{
+    private static FleetApiClient.WorkerInfo Info(int cpu, long mem, string? arch)
+        => new(
+            Id: Guid.NewGuid(),
+            Name: "w",
+            Status: WorkerStatus.Online,
+            IsEmbedded: false,
+            LastSeenAt: null,
+            MaxDiskUsageGb: 10,
+            RepoStoragePath: null,
+            Version: null,
+            ProcessorCount: cpu,
+            TotalMemoryMb: mem,
+            OperatingSystem: "Linux",
+            Architecture: arch,
+            CpuModel: null);
+
+    [Fact]
+    public void CapabilityLabel_renders_cores_memory_and_arch()
+    {
+        var vm = new WorkerItemViewModel(Info(8, 16 * 1024, "X64"), client: null!);
+        vm.CapabilityLabel.Should().Be("8 core(s) · 16,0 GB · X64");
+    }
+
+    [Fact]
+    public void CapabilityLabel_is_empty_when_no_capabilities_reported()
+    {
+        var vm = new WorkerItemViewModel(Info(0, 0, null), client: null!);
+        vm.CapabilityLabel.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CapabilityLabel_skips_missing_fields()
+    {
+        var vm = new WorkerItemViewModel(Info(4, 0, null), client: null!);
+        vm.CapabilityLabel.Should().Be("4 core(s)");
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the first-poller-wins job claim with a capability-aware selection so that on heterogeneous fleets (e.g. RPi4 + desktop PC) the beefier hardware always picks up new work and minimizes deployment time.

Closes #14.

## Scoring

`score = cores * 10 + (memoryMb / 1024) * 5 + archBonus`

- Arch bonus: `x64 / amd64 = 3`, `arm64 / aarch64 = 1`, otherwise `0`.
- Tiebreak: `Worker.Name` (ordinal), then `Worker.Id`.
- Workers with no reported capabilities score `0` (legacy / pre-upgrade) — see backward compat below.

Worked example:
- RPi4 (4 cores, 4 GB, arm64) → `40 + 20 + 1 = 61`
- Desktop PC (8 cores, 16 GB, x64) → `80 + 80 + 3 = 163` ✅

## Selection flow

`EfFleetStorage.ClaimNextJobAsync` now does, inside the existing `BEGIN IMMEDIATE` transaction:

1. Read all `Online` workers (other than the caller).
2. Treat the caller as a candidate even if the DB row is `Offline` or absent (guarantees backward compat with workers that haven't yet announced themselves Online).
3. `IWorkerSelector.SelectBest(candidates)`.
4. Only commit the claim when the best candidate is the caller; otherwise return `null` and let the better worker claim on its next poll.

The selector is registered as `IWorkerSelector` (default: `CapabilityWorkerSelector`) so it can be swapped in tests or future tuning.

## Capability reporting

Workers attach `ProcessorCount`, `TotalMemoryMb`, `OperatingSystem`, `Architecture` (and an optional `CpuModel`) to:

- `POST /api/workers/register` (initial bootstrap)
- `POST /api/workers/{id}/heartbeat` (every heartbeat — cheap, lets the coordinator self-heal after a wipe)

`WorkerCapabilityProbe` (in `DotnetFleet.Worker.Bootstrap`) collects them via `Environment.ProcessorCount`, `RuntimeInformation` and `GC.GetGCMemoryInfo().TotalAvailableMemoryBytes`.

## DB migration

Five new nullable / `DEFAULT 0` columns on `Workers` are added by the existing manual `ALTER TABLE` block in `CoordinatorHostBuilder.InitializeDatabaseAsync` (gated by `pragma_table_info` checks, so reruns and pre-existing DBs are safe). Helper `EnsureWorkerColumnAsync` added to keep the call site readable.

## Backward compatibility

- Older workers that don't yet report capabilities continue to register and heartbeat — missing fields stay `0` / `null`.
- A legacy worker that is the **only** idle candidate still wins the claim (score 0 vs no other candidates).
- A legacy worker that contends with a capability-reporting worker loses, which is the desired behavior.

## Tests

- `CapabilityWorkerSelectorTests` — formula, tiebreak, missing/legacy specs, RPi vs PC, low- vs high-spec PC.
- `CapabilityClaimIntegrationTests` — real SQLite, two registered workers + one queued job, asserts the higher-spec worker claims and the lower-spec one is correctly told `null`. Also covers Busy ⇒ low-spec can claim, and single-legacy-worker fallback.
- `WorkerItemViewModelTests` — UI label rendering for the new capability summary in the desktop app.
- Pre-existing storage tests updated to inject the default selector.

`dotnet test` → **76 / 76 passing**.