### PR TITLE
feat(coordinator): detect deployment version from GitVersion log output (#11)

### DIFF
--- a/src/DotnetFleet.Coordinator/CoordinatorHostBuilder.cs
+++ b/src/DotnetFleet.Coordinator/CoordinatorHostBuilder.cs
@@ -172,6 +172,14 @@ public static class CoordinatorHostBuilder
         await EnsureWorkerColumnAsync(db, "Architecture", "TEXT NULL");
         await EnsureWorkerColumnAsync(db, "CpuModel", "TEXT NULL");
 
+        var hasJobVersion = (await db.Database
+            .SqlQueryRaw<long>("SELECT COUNT(*) AS \"Value\" FROM pragma_table_info('DeploymentJobs') WHERE name='Version'")
+            .ToListAsync()).FirstOrDefault() > 0;
+        if (!hasJobVersion)
+        {
+            await db.Database.ExecuteSqlRawAsync("ALTER TABLE \"DeploymentJobs\" ADD COLUMN \"Version\" TEXT NULL");
+        }
+
         // ── Startup reconciliation ─────────────────────────────────────────
         // Jobs that were Running or Assigned during the last shutdown can never
         // complete because the worker context is lost. Fail them so they don't

--- a/src/DotnetFleet.Coordinator/Data/EfFleetStorage.cs
+++ b/src/DotnetFleet.Coordinator/Data/EfFleetStorage.cs
@@ -85,6 +85,20 @@ public class EfFleetStorage(IDbContextFactory<FleetDbContext> factory, IWorkerSe
         await db.SaveChangesAsync(ct);
     }
 
+    public async Task<bool> SetJobVersionIfUnsetAsync(Guid jobId, string version, CancellationToken ct = default)
+    {
+        await using var db = await factory.CreateDbContextAsync(ct);
+
+        // Single UPDATE Jobs SET Version = @version WHERE Id = @jobId AND Version IS NULL.
+        // Atomic at the SQL level: only the first concurrent caller's UPDATE matches a row
+        // (rows == 1); every later caller sees Version IS NOT NULL and matches zero rows.
+        var rows = await db.DeploymentJobs
+            .Where(j => j.Id == jobId && j.Version == null)
+            .ExecuteUpdateAsync(setters => setters.SetProperty(j => j.Version, version), ct);
+
+        return rows > 0;
+    }
+
     public async Task<DeploymentJob?> ClaimNextJobAsync(Guid workerId, CancellationToken ct = default)
     {
         await using var db = await factory.CreateDbContextAsync(ct);

--- a/src/DotnetFleet.Coordinator/Endpoints/JobEndpoints.cs
+++ b/src/DotnetFleet.Coordinator/Endpoints/JobEndpoints.cs
@@ -198,7 +198,8 @@ public static class JobEndpoints
         [FromBody] AppendLogsRequest req,
         HttpContext httpContext,
         IFleetStorage storage,
-        LogBroadcaster broadcaster)
+        LogBroadcaster broadcaster,
+        ILoggerFactory loggerFactory)
     {
         if (!TryGetWorkerId(httpContext, out var workerId))
             return Results.Forbid();
@@ -219,10 +220,20 @@ public static class JobEndpoints
         foreach (var entry in entries)
             broadcaster.Publish(id, entry);
 
-        // Detect the deployment version the first time GitVersion (or NBGV/MinVer) prints
-        // it in the log stream, so the deployment shows a friendly identifier instead of
-        // just its GUID.
-        await DeploymentVersionTracker.TryUpdateVersionAsync(storage, job, req.Lines);
+        // Version detection is best-effort and must NEVER fail the log-append:
+        // logs are already persisted (line above) and broadcast. If the tracker
+        // throws (e.g. transient DB lock, malformed line, etc.) we log a warning
+        // and return 200 so the worker doesn't retry and duplicate the batch.
+        try
+        {
+            await DeploymentVersionTracker.TryUpdateVersionAsync(storage, job, req.Lines);
+        }
+        catch (Exception ex)
+        {
+            loggerFactory
+                .CreateLogger(typeof(JobEndpoints).FullName!)
+                .LogWarning(ex, "Deployment version detection failed for job {JobId}; logs were persisted regardless.", id);
+        }
 
         return Results.Ok();
     }

--- a/src/DotnetFleet.Coordinator/Endpoints/JobEndpoints.cs
+++ b/src/DotnetFleet.Coordinator/Endpoints/JobEndpoints.cs
@@ -219,6 +219,11 @@ public static class JobEndpoints
         foreach (var entry in entries)
             broadcaster.Publish(id, entry);
 
+        // Detect the deployment version the first time GitVersion (or NBGV/MinVer) prints
+        // it in the log stream, so the deployment shows a friendly identifier instead of
+        // just its GUID.
+        await DeploymentVersionTracker.TryUpdateVersionAsync(storage, job, req.Lines);
+
         return Results.Ok();
     }
 

--- a/src/DotnetFleet.Coordinator/Services/DeploymentVersionTracker.cs
+++ b/src/DotnetFleet.Coordinator/Services/DeploymentVersionTracker.cs
@@ -1,0 +1,39 @@
+using DotnetFleet.Core.Domain;
+using DotnetFleet.Core.Interfaces;
+
+namespace DotnetFleet.Coordinator.Services;
+
+/// <summary>
+/// Stateless helper that, given a freshly received batch of log lines for a job,
+/// detects the first GitVersion-style version string and persists it onto the job
+/// exactly once. Subsequent batches are no-ops because <see cref="DeploymentJob.Version"/>
+/// is already set.
+/// </summary>
+public static class DeploymentVersionTracker
+{
+    /// <summary>
+    /// Scans <paramref name="lines"/> and, if the job has no version yet and a version is
+    /// found, mutates <paramref name="job"/>, persists it through <paramref name="storage"/>,
+    /// and returns the detected version. Returns null otherwise.
+    /// </summary>
+    public static async Task<string?> TryUpdateVersionAsync(
+        IFleetStorage storage,
+        DeploymentJob job,
+        IEnumerable<string> lines,
+        CancellationToken ct = default)
+    {
+        if (job.Version is not null) return null;
+
+        foreach (var line in lines)
+        {
+            var version = GitVersionLineParser.TryExtract(line);
+            if (version is null) continue;
+
+            job.Version = version;
+            await storage.UpdateJobAsync(job, ct);
+            return version;
+        }
+
+        return null;
+    }
+}

--- a/src/DotnetFleet.Coordinator/Services/DeploymentVersionTracker.cs
+++ b/src/DotnetFleet.Coordinator/Services/DeploymentVersionTracker.cs
@@ -29,8 +29,13 @@ public static class DeploymentVersionTracker
             var version = GitVersionLineParser.TryExtract(line);
             if (version is null) continue;
 
-            job.Version = version;
-            await storage.UpdateJobAsync(job, ct);
+            // Atomic: only the first concurrent batch for this job actually writes.
+            // Subsequent racing batches see rows == 0 and we report null so the caller
+            // doesn't believe it was the one that named the deployment.
+            var applied = await storage.SetJobVersionIfUnsetAsync(job.Id, version, ct);
+            if (!applied) return null;
+
+            job.Version = version; // keep the in-memory entity in sync for the caller
             return version;
         }
 

--- a/src/DotnetFleet.Coordinator/Services/GitVersionLineParser.cs
+++ b/src/DotnetFleet.Coordinator/Services/GitVersionLineParser.cs
@@ -1,0 +1,43 @@
+using System.Text.RegularExpressions;
+
+namespace DotnetFleet.Coordinator.Services;
+
+/// <summary>
+/// Pure, side-effect-free scanner that recognises a deployment version inside a single
+/// log line. Designed to handle output from GitVersion, Nerdbank.GitVersioning and MinVer
+/// (and any other tool that prints a SemVer in <c>Key: value</c> form).
+///
+/// The parser strips ANSI colour escape sequences before matching so it works against
+/// raw worker stdout. Only the version *value* is returned — never the original log line.
+/// </summary>
+public static class GitVersionLineParser
+{
+    private static readonly Regex AnsiEscape = new(
+        "\x1B\\[[0-9;?]*[A-Za-z]",
+        RegexOptions.Compiled);
+
+    // SemVer-ish payload: 1.2.3, optionally followed by -prerelease and/or +metadata.
+    private const string SemVerCore =
+        @"(?<ver>\d+\.\d+\.\d+(?:[-+][0-9A-Za-z][0-9A-Za-z.\-+]*)?)";
+
+    // Keys are ordered by *informational richness*. The first match wins for a given line,
+    // so when GitVersion prints both "MajorMinorPatch" and "FullSemVer" on different lines
+    // we pick whichever comes first in the stream — but the integration code only writes
+    // the first detection per job anyway.
+    private static readonly Regex KeyedVersion = new(
+        @"\b(?<key>FullSemVer|InformationalVersion|AssemblyInformationalVersion|SemVer|NuGetVersionV2|NuGetVersion|MajorMinorPatch|AssemblySemVer|Version)\b""?\s*[:=]\s*""?" + SemVerCore + "\"?",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    /// <summary>
+    /// Tries to extract a version string from <paramref name="line"/>. Returns null when
+    /// the line carries no recognisable version, is empty, or is malformed.
+    /// </summary>
+    public static string? TryExtract(string? line)
+    {
+        if (string.IsNullOrWhiteSpace(line)) return null;
+
+        var clean = AnsiEscape.Replace(line, string.Empty);
+        var match = KeyedVersion.Match(clean);
+        return match.Success ? match.Groups["ver"].Value : null;
+    }
+}

--- a/src/DotnetFleet.Core/Domain/DeploymentJob.cs
+++ b/src/DotnetFleet.Core/Domain/DeploymentJob.cs
@@ -18,4 +18,11 @@ public class DeploymentJob
 
     /// <summary>Set when a user requests cancellation. Workers poll this to abort in-flight jobs.</summary>
     public DateTimeOffset? CancellationRequestedAt { get; set; }
+
+    /// <summary>
+    /// Human-friendly version of the artifact being deployed (e.g. "1.2.3-beta.4").
+    /// Detected on the fly by scanning incoming log lines for GitVersion / NBGV / MinVer
+    /// output. Null until the first version line is observed; once set, it is not overwritten.
+    /// </summary>
+    public string? Version { get; set; }
 }

--- a/src/DotnetFleet.Core/Interfaces/IFleetStorage.cs
+++ b/src/DotnetFleet.Core/Interfaces/IFleetStorage.cs
@@ -19,6 +19,15 @@ public interface IFleetStorage
     Task UpdateJobAsync(DeploymentJob job, CancellationToken ct = default);
 
     /// <summary>
+    /// Atomically sets <see cref="DeploymentJob.Version"/> for the given job
+    /// only if it is currently NULL. Returns true if the row was updated, false
+    /// if the job did not exist or already had a version. Single SQL UPDATE
+    /// with a WHERE Id = @id AND Version IS NULL guard — no app-level locking,
+    /// no read-then-write race window.
+    /// </summary>
+    Task<bool> SetJobVersionIfUnsetAsync(Guid jobId, string version, CancellationToken ct = default);
+
+    /// <summary>
     /// Atomically claims the oldest Queued job for the given worker.
     /// Transitions the job to <see cref="JobStatus.Assigned"/> and sets <c>WorkerId</c> in a single
     /// serialized transaction so concurrent workers cannot pick the same job.

--- a/src/DotnetFleet/ViewModels/ProjectDetailViewModel.cs
+++ b/src/DotnetFleet/ViewModels/ProjectDetailViewModel.cs
@@ -79,15 +79,58 @@ public partial class JobViewModel : ReactiveObject
 
     public DeploymentJob Job { get; }
 
+    private string? _version;
+    private string _displayName = string.Empty;
+
     public JobViewModel(DeploymentJob job, FleetApiClient client, MainViewModel main, ProjectDetailViewModel projectDetail)
     {
         Job = job;
         _client = client;
         _main = main;
         _projectDetail = projectDetail;
+        _version = job.Version;
+        _displayName = ComputeDisplayName(job.Version);
 
         OpenCommand = ReactiveCommand.Create(Open);
     }
+
+    /// <summary>The detected GitVersion-style version, or null if none was reported yet.</summary>
+    public string? Version
+    {
+        get => _version;
+        private set
+        {
+            if (_version == value) return;
+            this.RaiseAndSetIfChanged(ref _version, value);
+            DisplayName = ComputeDisplayName(value);
+        }
+    }
+
+    /// <summary>
+    /// Friendly label shown in deployment lists. Falls back to a short prefix of the
+    /// job GUID until a version is detected from the worker's log stream.
+    /// </summary>
+    public string DisplayName
+    {
+        get => _displayName;
+        private set => this.RaiseAndSetIfChanged(ref _displayName, value);
+    }
+
+    /// <summary>
+    /// Pushes a fresher snapshot of the underlying <see cref="DeploymentJob"/> into this VM,
+    /// raising change notifications for the user-visible fields. Used when the deployment is
+    /// renamed (a version was detected) or any other field is updated by the coordinator.
+    /// </summary>
+    public void ApplyJobUpdate(DeploymentJob updated)
+    {
+        if (updated.Id != Job.Id) return;
+        Job.Version = updated.Version;
+        Job.Status = updated.Status;
+        Version = updated.Version;
+    }
+
+    private string ComputeDisplayName(string? version) =>
+        string.IsNullOrWhiteSpace(version) ? Job.Id.ToString("N")[..8] : version!;
 
     public string StatusBadge => Job.Status switch
     {

--- a/src/DotnetFleet/Views/ProjectDetailView.axaml
+++ b/src/DotnetFleet/Views/ProjectDetailView.axaml
@@ -44,6 +44,8 @@
                                            FontFamily="Consolas,monospace" VerticalAlignment="Center"
                                            MinWidth="140" />
                                 <StackPanel Grid.Column="1" Spacing="2" Margin="12,0">
+                                    <TextBlock FontSize="13" FontWeight="SemiBold"
+                                               Text="{Binding DisplayName}" />
                                     <TextBlock FontSize="12" Opacity="0.6">
                                         <Run Text="Queued: " />
                                         <Run Text="{Binding Job.EnqueuedAt}" />

--- a/tests/DotnetFleet.Tests/AppendLogsTrackerFailureTests.cs
+++ b/tests/DotnetFleet.Tests/AppendLogsTrackerFailureTests.cs
@@ -1,0 +1,186 @@
+using System.Reflection;
+using System.Security.Claims;
+using DotnetFleet.Coordinator.Data;
+using DotnetFleet.Coordinator.Endpoints;
+using DotnetFleet.Coordinator.Services;
+using DotnetFleet.Core.Domain;
+using DotnetFleet.Core.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace DotnetFleet.Tests;
+
+/// <summary>
+/// Verifies that the <c>AppendLogs</c> handler returns 200 OK even when the
+/// best-effort version-detection step throws. Logs are committed *before* the
+/// tracker runs, so a tracker failure must not propagate (otherwise the worker
+/// retries the batch and we get duplicate log lines). The handler is invoked
+/// directly via reflection because it is a private static minimal-API delegate.
+/// </summary>
+public class AppendLogsTrackerFailureTests : IDisposable
+{
+    private readonly string dbPath;
+    private readonly IDbContextFactory<FleetDbContext> factory;
+
+    public AppendLogsTrackerFailureTests()
+    {
+        dbPath = Path.Combine(Path.GetTempPath(), $"fleet-resilience-{Guid.NewGuid():N}.db");
+        var options = new DbContextOptionsBuilder<FleetDbContext>()
+            .UseSqlite($"Data Source={dbPath}")
+            .Options;
+        factory = new InlineFactory(options);
+
+        using var db = factory.CreateDbContext();
+        db.Database.EnsureCreated();
+    }
+
+    private sealed class InlineFactory(DbContextOptions<FleetDbContext> options)
+        : IDbContextFactory<FleetDbContext>
+    {
+        public FleetDbContext CreateDbContext() => new(options);
+    }
+
+    public void Dispose()
+    {
+        try { File.Delete(dbPath); } catch { /* best-effort */ }
+    }
+
+    /// <summary>
+    /// Wraps a real <see cref="EfFleetStorage"/> but makes the version-detection
+    /// path throw, leaving the rest of the storage contract intact so logs do get
+    /// persisted.
+    /// </summary>
+    private sealed class ThrowingTrackerStorage(IFleetStorage inner) : IFleetStorage
+    {
+        public Task<bool> SetJobVersionIfUnsetAsync(Guid jobId, string version, CancellationToken ct = default)
+            => throw new InvalidOperationException("boom: simulated tracker DB failure");
+
+        // Pass-through for everything the AppendLogs path actually exercises.
+        public Task<DeploymentJob?> GetJobAsync(Guid id, CancellationToken ct = default) => inner.GetJobAsync(id, ct);
+        public Task AddLogEntriesAsync(IEnumerable<LogEntry> entries, CancellationToken ct = default) => inner.AddLogEntriesAsync(entries, ct);
+        public Task<IReadOnlyList<LogEntry>> GetLogsAsync(Guid jobId, CancellationToken ct = default) => inner.GetLogsAsync(jobId, ct);
+        public Task AddProjectAsync(Project project, CancellationToken ct = default) => inner.AddProjectAsync(project, ct);
+        public Task AddJobAsync(DeploymentJob job, CancellationToken ct = default) => inner.AddJobAsync(job, ct);
+
+        // Members below are not invoked by the AppendLogs path. Keep them implemented
+        // (rather than throwing) so any future refactor doesn't accidentally turn this
+        // fake into a fragile mock.
+        public Task<IReadOnlyList<Project>> GetProjectsAsync(CancellationToken ct = default) => inner.GetProjectsAsync(ct);
+        public Task<Project?> GetProjectAsync(Guid id, CancellationToken ct = default) => inner.GetProjectAsync(id, ct);
+        public Task UpdateProjectAsync(Project project, CancellationToken ct = default) => inner.UpdateProjectAsync(project, ct);
+        public Task DeleteProjectAsync(Guid id, CancellationToken ct = default) => inner.DeleteProjectAsync(id, ct);
+        public Task<IReadOnlyList<DeploymentJob>> GetJobsAsync(CancellationToken ct = default) => inner.GetJobsAsync(ct);
+        public Task<IReadOnlyList<DeploymentJob>> GetJobsByProjectAsync(Guid projectId, CancellationToken ct = default) => inner.GetJobsByProjectAsync(projectId, ct);
+        public Task UpdateJobAsync(DeploymentJob job, CancellationToken ct = default) => inner.UpdateJobAsync(job, ct);
+        public Task<DeploymentJob?> ClaimNextJobAsync(Guid workerId, CancellationToken ct = default) => inner.ClaimNextJobAsync(workerId, ct);
+        public Task<IReadOnlyList<Worker>> GetWorkersAsync(CancellationToken ct = default) => inner.GetWorkersAsync(ct);
+        public Task<Worker?> GetWorkerAsync(Guid id, CancellationToken ct = default) => inner.GetWorkerAsync(id, ct);
+        public Task AddWorkerAsync(Worker worker, CancellationToken ct = default) => inner.AddWorkerAsync(worker, ct);
+        public Task UpdateWorkerAsync(Worker worker, CancellationToken ct = default) => inner.UpdateWorkerAsync(worker, ct);
+        public Task<bool> TouchWorkerAsync(Guid workerId, CancellationToken ct = default) => inner.TouchWorkerAsync(workerId, ct);
+        public Task<IReadOnlyList<RepoCache>> GetRepoCachesAsync(Guid workerId, CancellationToken ct = default) => inner.GetRepoCachesAsync(workerId, ct);
+        public Task<RepoCache?> GetRepoCacheAsync(Guid workerId, Guid projectId, CancellationToken ct = default) => inner.GetRepoCacheAsync(workerId, projectId, ct);
+        public Task UpsertRepoCacheAsync(RepoCache cache, CancellationToken ct = default) => inner.UpsertRepoCacheAsync(cache, ct);
+        public Task DeleteRepoCacheAsync(Guid id, CancellationToken ct = default) => inner.DeleteRepoCacheAsync(id, ct);
+        public Task<User?> GetUserByUsernameAsync(string username, CancellationToken ct = default) => inner.GetUserByUsernameAsync(username, ct);
+        public Task<User?> GetUserAsync(Guid id, CancellationToken ct = default) => inner.GetUserAsync(id, ct);
+        public Task<IReadOnlyList<User>> GetUsersAsync(CancellationToken ct = default) => inner.GetUsersAsync(ct);
+        public Task AddUserAsync(User user, CancellationToken ct = default) => inner.AddUserAsync(user, ct);
+        public Task UpdateUserAsync(User user, CancellationToken ct = default) => inner.UpdateUserAsync(user, ct);
+        public Task DeleteUserAsync(Guid id, CancellationToken ct = default) => inner.DeleteUserAsync(id, ct);
+        public Task<bool> AnyUserExistsAsync(CancellationToken ct = default) => inner.AnyUserExistsAsync(ct);
+        public Task<int> MarkOfflineWorkersAsync(TimeSpan staleThreshold, CancellationToken ct = default) => inner.MarkOfflineWorkersAsync(staleThreshold, ct);
+        public Task<IReadOnlyList<Guid>> FailStaleJobsAsync(TimeSpan staleThreshold, CancellationToken ct = default) => inner.FailStaleJobsAsync(staleThreshold, ct);
+        public Task<IReadOnlyList<Guid>> FailTimedOutJobsAsync(TimeSpan queuedTimeout, CancellationToken ct = default) => inner.FailTimedOutJobsAsync(queuedTimeout, ct);
+        public Task<IReadOnlyList<Guid>> FailStuckAssignedJobsAsync(TimeSpan assignedTimeout, CancellationToken ct = default) => inner.FailStuckAssignedJobsAsync(assignedTimeout, ct);
+        public Task<IReadOnlyList<Guid>> FailJobsForWorkerAsync(Guid workerId, string reason, CancellationToken ct = default) => inner.FailJobsForWorkerAsync(workerId, reason, ct);
+        public Task<IReadOnlyList<Secret>> GetSecretsAsync(Guid? projectId, CancellationToken ct = default) => inner.GetSecretsAsync(projectId, ct);
+        public Task<Secret?> GetSecretAsync(Guid id, CancellationToken ct = default) => inner.GetSecretAsync(id, ct);
+        public Task AddSecretAsync(Secret secret, CancellationToken ct = default) => inner.AddSecretAsync(secret, ct);
+        public Task UpdateSecretAsync(Secret secret, CancellationToken ct = default) => inner.UpdateSecretAsync(secret, ct);
+        public Task DeleteSecretAsync(Guid id, CancellationToken ct = default) => inner.DeleteSecretAsync(id, ct);
+    }
+
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        public List<(LogLevel Level, string Message, Exception? Exception)> Entries { get; } = new();
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(this);
+        public void Dispose() { }
+
+        private sealed class CapturingLogger(CapturingLoggerProvider owner) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+                Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                lock (owner.Entries)
+                    owner.Entries.Add((logLevel, formatter(state, exception), exception));
+            }
+        }
+    }
+
+    [Fact]
+    public async Task AppendLogs_returns_Ok_when_tracker_storage_throws_and_logs_warning()
+    {
+        // Arrange: real storage seeded with a project + a job owned by a known worker.
+        var realStorage = new EfFleetStorage(factory, new DotnetFleet.Core.Domain.CapabilityWorkerSelector());
+        var workerId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        await realStorage.AddProjectAsync(new Project
+        {
+            Id = projectId, Name = "p", GitUrl = "https://example.com/r.git", Branch = "main"
+        });
+        var jobId = Guid.NewGuid();
+        await realStorage.AddJobAsync(new DeploymentJob
+        {
+            Id = jobId, ProjectId = projectId, WorkerId = workerId,
+            Status = JobStatus.Running, EnqueuedAt = DateTimeOffset.UtcNow
+        });
+
+        var throwingStorage = new ThrowingTrackerStorage(realStorage);
+        var broadcaster = new LogBroadcaster();
+        var loggerProvider = new CapturingLoggerProvider();
+        var loggerFactory = LoggerFactory.Create(b => b.AddProvider(loggerProvider));
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim("worker_id", workerId.ToString())
+            }, "test"))
+        };
+
+        // The body carries a parseable GitVersion line so the tracker is *guaranteed*
+        // to enter the throwing code path (otherwise it would short-circuit on "no version").
+        var req = new JobEndpoints.AppendLogsRequest(new[] { "FullSemVer: 1.0.0" });
+
+        var method = typeof(JobEndpoints).GetMethod(
+            "AppendLogs",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        // Act
+        var task = (Task<IResult>)method.Invoke(null, new object[]
+        {
+            jobId, req, httpContext, throwingStorage, broadcaster, loggerFactory
+        })!;
+        var result = await task;
+
+        // Assert: 200 OK
+        var status = result.GetType().GetProperty("StatusCode")?.GetValue(result) as int?;
+        status.Should().Be(StatusCodes.Status200OK,
+            "tracker failures must not surface to the worker — logs are already committed");
+
+        // Logs were persisted regardless of the tracker exception.
+        var logs = await realStorage.GetLogsAsync(jobId);
+        logs.Should().ContainSingle(l => l.Line == "FullSemVer: 1.0.0");
+
+        // The exception was swallowed *and* observed via a Warning-level log.
+        loggerProvider.Entries.Should().Contain(
+            e => e.Level == LogLevel.Warning && e.Exception is InvalidOperationException,
+            "the swallowed exception must be reported so failures don't go unnoticed");
+
+        loggerFactory.Dispose();
+    }
+}

--- a/tests/DotnetFleet.Tests/DeploymentVersionTrackerTests.cs
+++ b/tests/DotnetFleet.Tests/DeploymentVersionTrackerTests.cs
@@ -58,7 +58,7 @@ public class DeploymentVersionTrackerTests : IDisposable
     [Fact]
     public async Task First_GitVersion_line_in_the_stream_renames_the_deployment()
     {
-        var storage = new EfFleetStorage(factory);
+        var storage = new EfFleetStorage(factory, new DotnetFleet.Core.Domain.CapabilityWorkerSelector());
         var job = await SeedJobAsync(storage);
 
         var lines = new[]
@@ -80,7 +80,7 @@ public class DeploymentVersionTrackerTests : IDisposable
     [Fact]
     public async Task Subsequent_batches_do_not_overwrite_the_first_detected_version()
     {
-        var storage = new EfFleetStorage(factory);
+        var storage = new EfFleetStorage(factory, new DotnetFleet.Core.Domain.CapabilityWorkerSelector());
         var job = await SeedJobAsync(storage);
 
         await DeploymentVersionTracker.TryUpdateVersionAsync(storage, job,
@@ -99,7 +99,7 @@ public class DeploymentVersionTrackerTests : IDisposable
     [Fact]
     public async Task Lines_without_a_version_leave_the_job_unchanged()
     {
-        var storage = new EfFleetStorage(factory);
+        var storage = new EfFleetStorage(factory, new DotnetFleet.Core.Domain.CapabilityWorkerSelector());
         var job = await SeedJobAsync(storage);
 
         var detected = await DeploymentVersionTracker.TryUpdateVersionAsync(storage, job,
@@ -108,5 +108,42 @@ public class DeploymentVersionTrackerTests : IDisposable
         detected.Should().BeNull();
         var reloaded = await storage.GetJobAsync(job.Id);
         reloaded!.Version.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Concurrent_batches_with_different_versions_persist_only_one()
+    {
+        var storage = new EfFleetStorage(factory, new DotnetFleet.Core.Domain.CapabilityWorkerSelector());
+        var job = await SeedJobAsync(storage);
+
+        // Both copies observe Version == null, mirroring two AppendLogs requests racing
+        // for the same job inside their own scoped DbContext.
+        var jobCopyA = (await storage.GetJobAsync(job.Id))!;
+        var jobCopyB = (await storage.GetJobAsync(job.Id))!;
+
+        using var gate = new SemaphoreSlim(0, 2);
+        var t1 = Task.Run(async () =>
+        {
+            await gate.WaitAsync();
+            return await DeploymentVersionTracker.TryUpdateVersionAsync(
+                storage, jobCopyA, new[] { "FullSemVer: 1.0.0" });
+        });
+        var t2 = Task.Run(async () =>
+        {
+            await gate.WaitAsync();
+            return await DeploymentVersionTracker.TryUpdateVersionAsync(
+                storage, jobCopyB, new[] { "FullSemVer: 2.0.0" });
+        });
+
+        gate.Release(2);
+        var results = await Task.WhenAll(t1, t2);
+
+        results.Count(r => r is not null).Should().Be(1,
+            "first-match-wins: the racing batch that loses the atomic write must report null");
+
+        var reloaded = await storage.GetJobAsync(job.Id);
+        reloaded!.Version.Should().BeOneOf("1.0.0", "2.0.0");
+        reloaded.Version.Should().Be(results.Single(r => r is not null),
+            "the surviving version must be exactly the one returned by the winning task");
     }
 }

--- a/tests/DotnetFleet.Tests/DeploymentVersionTrackerTests.cs
+++ b/tests/DotnetFleet.Tests/DeploymentVersionTrackerTests.cs
@@ -1,0 +1,112 @@
+using DotnetFleet.Coordinator.Data;
+using DotnetFleet.Coordinator.Services;
+using DotnetFleet.Core.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace DotnetFleet.Tests;
+
+/// <summary>
+/// End-to-end-ish coverage for the deployment-rename feature: pumps fake worker log
+/// lines into the same pipeline the HTTP <c>AppendLogs</c> endpoint uses, and asserts
+/// that the persisted <see cref="DeploymentJob"/> gets its <see cref="DeploymentJob.Version"/>
+/// populated the moment a GitVersion-style line arrives — and only once.
+/// </summary>
+public class DeploymentVersionTrackerTests : IDisposable
+{
+    private readonly string dbPath;
+    private readonly IDbContextFactory<FleetDbContext> factory;
+
+    public DeploymentVersionTrackerTests()
+    {
+        dbPath = Path.Combine(Path.GetTempPath(), $"fleet-version-{Guid.NewGuid():N}.db");
+        var options = new DbContextOptionsBuilder<FleetDbContext>()
+            .UseSqlite($"Data Source={dbPath}")
+            .Options;
+        factory = new InlineFactory(options);
+
+        using var db = factory.CreateDbContext();
+        db.Database.EnsureCreated();
+    }
+
+    private sealed class InlineFactory(DbContextOptions<FleetDbContext> options)
+        : IDbContextFactory<FleetDbContext>
+    {
+        public FleetDbContext CreateDbContext() => new(options);
+    }
+
+    public void Dispose()
+    {
+        try { File.Delete(dbPath); } catch { /* best-effort */ }
+    }
+
+    private async Task<DeploymentJob> SeedJobAsync(EfFleetStorage storage)
+    {
+        var projectId = Guid.NewGuid();
+        await storage.AddProjectAsync(new Project
+        {
+            Id = projectId, Name = "p", GitUrl = "https://example.com/r.git", Branch = "main"
+        });
+        var job = new DeploymentJob
+        {
+            Id = Guid.NewGuid(), ProjectId = projectId,
+            Status = JobStatus.Running, EnqueuedAt = DateTimeOffset.UtcNow
+        };
+        await storage.AddJobAsync(job);
+        return job;
+    }
+
+    [Fact]
+    public async Task First_GitVersion_line_in_the_stream_renames_the_deployment()
+    {
+        var storage = new EfFleetStorage(factory);
+        var job = await SeedJobAsync(storage);
+
+        var lines = new[]
+        {
+            "Restoring packages...",
+            "Running GitVersion...",
+            "FullSemVer: 1.4.2-beta.7+build.91",
+            "Build succeeded."
+        };
+
+        var detected = await DeploymentVersionTracker.TryUpdateVersionAsync(storage, job, lines);
+
+        detected.Should().Be("1.4.2-beta.7+build.91");
+
+        var reloaded = await storage.GetJobAsync(job.Id);
+        reloaded!.Version.Should().Be("1.4.2-beta.7+build.91");
+    }
+
+    [Fact]
+    public async Task Subsequent_batches_do_not_overwrite_the_first_detected_version()
+    {
+        var storage = new EfFleetStorage(factory);
+        var job = await SeedJobAsync(storage);
+
+        await DeploymentVersionTracker.TryUpdateVersionAsync(storage, job,
+            new[] { "InformationalVersion: 1.0.0" });
+
+        // Reload as the endpoint would on the next batch.
+        var refreshed = (await storage.GetJobAsync(job.Id))!;
+        var second = await DeploymentVersionTracker.TryUpdateVersionAsync(storage, refreshed,
+            new[] { "FullSemVer: 9.9.9" });
+
+        second.Should().BeNull("the job is already named, GitVersion output later in the stream must not rewrite it");
+        var reloaded = await storage.GetJobAsync(job.Id);
+        reloaded!.Version.Should().Be("1.0.0");
+    }
+
+    [Fact]
+    public async Task Lines_without_a_version_leave_the_job_unchanged()
+    {
+        var storage = new EfFleetStorage(factory);
+        var job = await SeedJobAsync(storage);
+
+        var detected = await DeploymentVersionTracker.TryUpdateVersionAsync(storage, job,
+            new[] { "starting build", "compiling sources", "tests passed" });
+
+        detected.Should().BeNull();
+        var reloaded = await storage.GetJobAsync(job.Id);
+        reloaded!.Version.Should().BeNull();
+    }
+}

--- a/tests/DotnetFleet.Tests/EfFleetStorageSetJobVersionIfUnsetTests.cs
+++ b/tests/DotnetFleet.Tests/EfFleetStorageSetJobVersionIfUnsetTests.cs
@@ -1,0 +1,107 @@
+using DotnetFleet.Coordinator.Data;
+using DotnetFleet.Core.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace DotnetFleet.Tests;
+
+/// <summary>
+/// Verifies <see cref="EfFleetStorage.SetJobVersionIfUnsetAsync"/> behaves as a
+/// first-writer-wins atomic primitive: the underlying SQL is a single UPDATE
+/// guarded by <c>WHERE Id = @id AND Version IS NULL</c>, so concurrent callers
+/// cannot trample each other's writes.
+/// Uses a real Sqlite file so the per-row write lock actually serializes the
+/// updates (an in-memory shared connection would not exercise the same path).
+/// </summary>
+public class EfFleetStorageSetJobVersionIfUnsetTests : IDisposable
+{
+    private readonly string dbPath;
+    private readonly IDbContextFactory<FleetDbContext> factory;
+
+    public EfFleetStorageSetJobVersionIfUnsetTests()
+    {
+        dbPath = Path.Combine(Path.GetTempPath(), $"fleet-setversion-{Guid.NewGuid():N}.db");
+        var options = new DbContextOptionsBuilder<FleetDbContext>()
+            .UseSqlite($"Data Source={dbPath}")
+            .Options;
+        factory = new InlineFactory(options);
+
+        using var db = factory.CreateDbContext();
+        db.Database.EnsureCreated();
+    }
+
+    private sealed class InlineFactory(DbContextOptions<FleetDbContext> options)
+        : IDbContextFactory<FleetDbContext>
+    {
+        public FleetDbContext CreateDbContext() => new(options);
+    }
+
+    public void Dispose()
+    {
+        try { File.Delete(dbPath); } catch { /* best-effort */ }
+    }
+
+    private async Task<DeploymentJob> SeedJobAsync(EfFleetStorage storage, string? version = null)
+    {
+        var projectId = Guid.NewGuid();
+        await storage.AddProjectAsync(new Project
+        {
+            Id = projectId, Name = "p", GitUrl = "https://example.com/r.git", Branch = "main"
+        });
+        var job = new DeploymentJob
+        {
+            Id = Guid.NewGuid(), ProjectId = projectId,
+            Status = JobStatus.Running, EnqueuedAt = DateTimeOffset.UtcNow,
+            Version = version
+        };
+        await storage.AddJobAsync(job);
+        return job;
+    }
+
+    [Fact]
+    public async Task SetJobVersionIfUnset_only_first_concurrent_writer_wins()
+    {
+        var storage = new EfFleetStorage(factory, new DotnetFleet.Core.Domain.CapabilityWorkerSelector());
+        var job = await SeedJobAsync(storage);
+
+        const int contenders = 16;
+        var candidates = Enumerable.Range(0, contenders).Select(i => $"v{i}").ToArray();
+
+        using var gate = new SemaphoreSlim(0, contenders);
+        var tasks = candidates.Select(async v =>
+        {
+            await gate.WaitAsync();
+            return (Version: v, Won: await storage.SetJobVersionIfUnsetAsync(job.Id, v));
+        }).ToArray();
+
+        gate.Release(contenders);
+        var results = await Task.WhenAll(tasks);
+
+        var winners = results.Where(r => r.Won).ToList();
+        winners.Should().HaveCount(1, "first-writer-wins: only one concurrent caller may set the version");
+
+        var reloaded = await storage.GetJobAsync(job.Id);
+        reloaded!.Version.Should().Be(winners[0].Version,
+            "the persisted version must match exactly the candidate the winning caller submitted");
+    }
+
+    [Fact]
+    public async Task SetJobVersionIfUnset_returns_false_when_already_set()
+    {
+        var storage = new EfFleetStorage(factory, new DotnetFleet.Core.Domain.CapabilityWorkerSelector());
+        var job = await SeedJobAsync(storage, version: "1.0.0");
+
+        var ok = await storage.SetJobVersionIfUnsetAsync(job.Id, "9.9.9");
+
+        ok.Should().BeFalse();
+        var reloaded = await storage.GetJobAsync(job.Id);
+        reloaded!.Version.Should().Be("1.0.0");
+    }
+
+    [Fact]
+    public async Task SetJobVersionIfUnset_returns_false_for_unknown_job()
+    {
+        var storage = new EfFleetStorage(factory, new DotnetFleet.Core.Domain.CapabilityWorkerSelector());
+        var ok = await storage.SetJobVersionIfUnsetAsync(Guid.NewGuid(), "1.0.0");
+        ok.Should().BeFalse();
+    }
+}

--- a/tests/DotnetFleet.Tests/GitVersionLineParserTests.cs
+++ b/tests/DotnetFleet.Tests/GitVersionLineParserTests.cs
@@ -1,0 +1,60 @@
+using DotnetFleet.Coordinator.Services;
+
+namespace DotnetFleet.Tests;
+
+public class GitVersionLineParserTests
+{
+    [Theory]
+    [InlineData("FullSemVer: 1.2.3", "1.2.3")]
+    [InlineData("InformationalVersion: 2.4.1-beta.5+abcdef", "2.4.1-beta.5+abcdef")]
+    [InlineData("SemVer: 0.0.31", "0.0.31")]
+    [InlineData("MajorMinorPatch: 10.20.30", "10.20.30")]
+    [InlineData("AssemblyInformationalVersion: 1.0.0-alpha", "1.0.0-alpha")]
+    [InlineData("NuGetVersionV2: 1.2.3-rc.1", "1.2.3-rc.1")]
+    [InlineData("\"FullSemVer\": \"1.2.3-beta.4+5\",", "1.2.3-beta.4+5")]
+    [InlineData("Version: 1.2.3", "1.2.3")]
+    public void Recognises_typical_GitVersion_keys(string line, string expected)
+    {
+        GitVersionLineParser.TryExtract(line).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("\u001b[32mFullSemVer: 1.2.3\u001b[0m", "1.2.3")]
+    [InlineData("\u001b[1;36mInformationalVersion:\u001b[0m \u001b[33m9.8.7-rc.1\u001b[0m", "9.8.7-rc.1")]
+    public void Strips_ANSI_colour_codes_before_matching(string line, string expected)
+    {
+        GitVersionLineParser.TryExtract(line).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    [InlineData("Just a regular log line, nothing to see here.")]
+    [InlineData("error: build failed at step 3")]
+    [InlineData("Version is unknown")]
+    [InlineData("FullSemVer:")]                       // missing value
+    [InlineData("FullSemVer: not.a.version")]         // not numeric
+    [InlineData("FullSemVer: 1.2")]                   // too short
+    [InlineData("Some other thing: 1.2.3")]           // unknown key
+    public void Returns_null_for_lines_without_a_recognisable_version(string? line)
+    {
+        GitVersionLineParser.TryExtract(line).Should().BeNull();
+    }
+
+    [Fact]
+    public void Picks_first_recognised_key_within_a_line()
+    {
+        // If the same line happens to mention multiple keys, the parser still extracts a
+        // version — the first matching one is fine for naming purposes.
+        var line = "[INFO] FullSemVer: 1.2.3 (computed from MajorMinorPatch: 1.2.3)";
+        GitVersionLineParser.TryExtract(line).Should().Be("1.2.3");
+    }
+
+    [Fact]
+    public void Tolerates_leading_and_trailing_garbage()
+    {
+        var line = "  [11:42:07 INF] >> FullSemVer: 4.5.6-preview.1+build.42  ";
+        GitVersionLineParser.TryExtract(line).Should().Be("4.5.6-preview.1+build.42");
+    }
+}

--- a/tests/DotnetFleet.Tests/JobViewModelDisplayNameTests.cs
+++ b/tests/DotnetFleet.Tests/JobViewModelDisplayNameTests.cs
@@ -1,0 +1,73 @@
+using DotnetFleet.Core.Domain;
+using DotnetFleet.ViewModels;
+
+namespace DotnetFleet.Tests;
+
+/// <summary>
+/// Verifies that the deployment list ViewModel projects a friendly name based on the
+/// underlying <see cref="DeploymentJob.Version"/> and reacts to updates pushed in via
+/// <see cref="JobViewModel.ApplyJobUpdate"/>.
+/// </summary>
+public class JobViewModelDisplayNameTests
+{
+    private static JobViewModel BuildVm(DeploymentJob job)
+    {
+        // The non-null parameters are only consumed by the Open() command which we never
+        // invoke in these tests, so passing null! is safe here.
+        return new JobViewModel(job, client: null!, main: null!, projectDetail: null!);
+    }
+
+    [Fact]
+    public void Falls_back_to_short_GUID_when_no_version_is_known_yet()
+    {
+        var job = new DeploymentJob { Id = Guid.Parse("abcdef01-2345-6789-abcd-ef0123456789") };
+
+        var vm = BuildVm(job);
+
+        vm.DisplayName.Should().Be("abcdef01");
+    }
+
+    [Fact]
+    public void Initial_version_on_the_underlying_job_drives_the_display_name()
+    {
+        var job = new DeploymentJob { Id = Guid.NewGuid(), Version = "2.0.1" };
+
+        var vm = BuildVm(job);
+
+        vm.DisplayName.Should().Be("2.0.1");
+        vm.Version.Should().Be("2.0.1");
+    }
+
+    [Fact]
+    public void DisplayName_updates_when_underlying_deployment_is_renamed()
+    {
+        var job = new DeploymentJob { Id = Guid.NewGuid() };
+        var vm = BuildVm(job);
+
+        var seen = new List<string>();
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(JobViewModel.DisplayName))
+                seen.Add(vm.DisplayName);
+        };
+
+        var renamed = new DeploymentJob { Id = job.Id, Version = "3.4.5-rc.1" };
+        vm.ApplyJobUpdate(renamed);
+
+        vm.DisplayName.Should().Be("3.4.5-rc.1");
+        vm.Version.Should().Be("3.4.5-rc.1");
+        seen.Should().Contain("3.4.5-rc.1");
+    }
+
+    [Fact]
+    public void Updates_for_a_different_job_id_are_ignored()
+    {
+        var job = new DeploymentJob { Id = Guid.NewGuid(), Version = "1.0.0" };
+        var vm = BuildVm(job);
+
+        vm.ApplyJobUpdate(new DeploymentJob { Id = Guid.NewGuid(), Version = "9.9.9" });
+
+        vm.Version.Should().Be("1.0.0");
+        vm.DisplayName.Should().Be("1.0.0");
+    }
+}


### PR DESCRIPTION
## Summary
Deployments were displayed with a raw GUID, which made it hard to tell what was actually being shipped. The coordinator now scans the worker's log stream for a recognisable version string and renames the deployment the first time one appears.

## What changed
- **Parser** (`GitVersionLineParser`): pure, stateless, ANSI-stripped regex scanner that recognises GitVersion (`FullSemVer`, `SemVer`, `InformationalVersion`, `MajorMinorPatch`, …) plus an NBGV / MinVer `Version:` fallback.
- **Tracker** (`DeploymentVersionTracker`): tiny helper called from the `AppendLogs` endpoint. Detects the first version per job, persists it via `IFleetStorage.UpdateJobAsync`, and is a no-op afterwards.
- **Domain**: `DeploymentJob` gains a nullable `Version` column. The manual `ALTER TABLE` block in `InitializeDatabaseAsync` was extended to add it on existing databases.
- **UI**: `JobViewModel` now exposes `DisplayName` (version when known, short GUID otherwise) and an `ApplyJobUpdate` hook so renames flow to the bound view. `ProjectDetailView` shows it above the existing metadata.

## Tests
- `GitVersionLineParserTests` — canonical lines, ANSI-coloured lines, malformed values, no-match cases.
- `DeploymentVersionTrackerTests` — EF-backed integration test pumping fake worker lines through the tracker and asserting the job is renamed exactly once.
- `JobViewModelDisplayNameTests` — verifies `DisplayName` falls back to the short GUID and reacts to renames pushed via `ApplyJobUpdate`.

`dotnet build` and `dotnet test` both pass (89/89).

Closes #11