### PR TITLE
feat(android): add Android head and include in deployer

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Browser" Version="$(AvaloniaVersion)" />
+    <PackageVersion Include="Avalonia.Android" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Markup.Xaml.Loader" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />

--- a/DotnetFleet.slnx
+++ b/DotnetFleet.slnx
@@ -2,6 +2,7 @@
   <Folder Name="/src/">
     <Project Path="src/DotnetFleet.Api.Client/DotnetFleet.Api.Client.csproj" />
     <Project Path="src/DotnetFleet.Browser/DotnetFleet.Browser.csproj" />
+    <Project Path="src/DotnetFleet.Android/DotnetFleet.Android.csproj" />
     <Project Path="src/DotnetFleet.Coordinator/DotnetFleet.Coordinator.csproj" />
     <Project Path="src/DotnetFleet.Core/DotnetFleet.Core.csproj" />
     <Project Path="src/DotnetFleet.Desktop/DotnetFleet.Desktop.csproj" />

--- a/deployer.yaml
+++ b/deployer.yaml
@@ -19,6 +19,22 @@ github:
           arch: [x64]
         - type: dmg
           arch: [x64, arm64]
+    - project: src/DotnetFleet.Android/DotnetFleet.Android.csproj
+      formats:
+        - type: Apk
+          arch: [arm64]
+          signing:
+            keystore:
+              from: env
+              name: ANDROID_KEYSTORE_BASE64
+              encoding: base64
+            storePassword:
+              from: env
+              name: ANDROID_SIGNING_STORE_PASS
+            keyAlias: android
+            keyPassword:
+              from: env
+              name: ANDROID_SIGNING_KEY_PASS
 
 nuget:
   enabled: true

--- a/src/DotnetFleet.Android/DotnetFleet.Android.csproj
+++ b/src/DotnetFleet.Android/DotnetFleet.Android.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-android</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <SupportedOSPlatformVersion>23</SupportedOSPlatformVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>DotnetFleet.Android</RootNamespace>
+    <AssemblyName>DotnetFleet.Android</AssemblyName>
+    <ApplicationId>com.superjmn.dotnetfleet</ApplicationId>
+    <ApplicationVersion>1</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+    <ApplicationTitle>DotnetFleet</ApplicationTitle>
+    <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <ApplicationId>com.superjmn.dotnetfleet.debug</ApplicationId>
+    <ApplicationTitle>DotnetFleet (Debug)</ApplicationTitle>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <PublishTrimmed>false</PublishTrimmed>
+    <TrimMode>none</TrimMode>
+    <RunAOTCompilation>false</RunAOTCompilation>
+    <EnableAssemblyILStripping>false</EnableAssemblyILStripping>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Android" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DotnetFleet\DotnetFleet.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/DotnetFleet.Android/DotnetFleetAndroidApplication.cs
+++ b/src/DotnetFleet.Android/DotnetFleetAndroidApplication.cs
@@ -1,0 +1,24 @@
+using Android.App;
+using Android.Runtime;
+using Avalonia;
+using Avalonia.Android;
+using ReactiveUI.Avalonia;
+
+namespace DotnetFleet.Android;
+
+[Application]
+public class DotnetFleetAndroidApplication : AvaloniaAndroidApplication<global::DotnetFleet.App>
+{
+    public DotnetFleetAndroidApplication(IntPtr handle, JniHandleOwnership transfer)
+        : base(handle, transfer)
+    {
+    }
+
+    protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)
+    {
+        return base.CustomizeAppBuilder(builder)
+            .UseReactiveUI(_ => { })
+            .WithInterFont()
+            .LogToTrace();
+    }
+}

--- a/src/DotnetFleet.Android/MainActivity.cs
+++ b/src/DotnetFleet.Android/MainActivity.cs
@@ -1,0 +1,16 @@
+using Android.App;
+using Android.Content.PM;
+using Avalonia.Android;
+
+namespace DotnetFleet.Android;
+
+[Activity(
+    Label = "DotnetFleet",
+    Theme = "@style/MyTheme.NoActionBar",
+    MainLauncher = true,
+    ConfigurationChanges = ConfigChanges.Orientation
+                         | ConfigChanges.ScreenSize
+                         | ConfigChanges.UiMode)]
+public class MainActivity : AvaloniaMainActivity
+{
+}

--- a/src/DotnetFleet.Android/Properties/AndroidManifest.xml
+++ b/src/DotnetFleet.Android/Properties/AndroidManifest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application
+    android:allowBackup="true"
+    android:label="DotnetFleet"
+    android:supportsRtl="true"
+    android:theme="@style/MyTheme.NoActionBar"
+    android:enableOnBackInvokedCallback="true" />
+  <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="36" />
+  <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+</manifest>

--- a/src/DotnetFleet.Android/Resources/values/styles.xml
+++ b/src/DotnetFleet.Android/Resources/values/styles.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<resources>
+  <style name="MyTheme.NoActionBar" parent="android:Theme.Material.Light.NoActionBar">
+    <item name="android:windowNoTitle">true</item>
+  </style>
+</resources>


### PR DESCRIPTION
Mirrors the Pokemon Android head structure (simplified, no audio assets):

- `DotnetFleet.Android` project targeting `net10.0-android` (minSdk 23)
- `AvaloniaMainActivity` host + `AvaloniaAndroidApplication<App>`
- Reuses the shared `DotnetFleet` UI assembly via project reference
- Adds `Avalonia.Android` to `Directory.Packages.props`
- Registers the project in `DotnetFleet.slnx`
- `deployer.yaml`: adds `Apk` (arm64) target with the same env-driven signing config used by the Pokemon repo (`ANDROID_KEYSTORE_BASE64`, `ANDROID_SIGNING_STORE_PASS`, `ANDROID_SIGNING_KEY_PASS`, alias `android`)

Verified locally:
- `dotnet build -c Release` ✅
- `dotnet publish -c Release -p:RuntimeIdentifier=android-arm64` produces signed APK ✅