### PR TITLE
feat(android): Android head with AppCompat theme + cleartext HTTP

### DIFF
--- a/src/DotnetFleet.Android/Properties/AndroidManifest.xml
+++ b/src/DotnetFleet.Android/Properties/AndroidManifest.xml
@@ -5,7 +5,8 @@
     android:label="DotnetFleet"
     android:supportsRtl="true"
     android:theme="@style/MyTheme.NoActionBar"
-    android:enableOnBackInvokedCallback="true" />
+    android:enableOnBackInvokedCallback="true"
+    android:usesCleartextTraffic="true" />
   <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="36" />
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/src/DotnetFleet.Android/Resources/values/styles.xml
+++ b/src/DotnetFleet.Android/Resources/values/styles.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <resources>
-  <style name="MyTheme.NoActionBar" parent="android:Theme.Material.Light.NoActionBar">
+  <style name="MyTheme" />
+
+  <style name="MyTheme.NoActionBar" parent="Theme.AppCompat.DayNight.NoActionBar">
+    <item name="android:windowActionBar">false</item>
     <item name="android:windowNoTitle">true</item>
   </style>
 </resources>


### PR DESCRIPTION
Brings the Android head into master plus two startup fixes discovered while testing on a physical device (Xiaomi MIUI):

- Switch the activity theme to `Theme.AppCompat.DayNight.NoActionBar` so `AvaloniaMainActivity` (an `AppCompatActivity`) doesn't crash at startup.
- Enable `android:usesCleartextTraffic="true"` so the app can connect to LAN coordinators over plain HTTP on Android 9+.

Verified: APK installs and launches on physical device, MainActivity displayed in ~1.8s, no `UnsatisfiedLinkError`/`FATAL`.