### PR TITLE
[codex] Add native Windows service installation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,6 +39,7 @@
     <!-- DI -->
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />
     <!-- Logging -->
     <PackageVersion Include="Serilog" Version="4.3.0" />

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You now have a working CI/CD pipeline. Add projects from the [Desktop App](#desk
   - [Step 2 — Connect Workers](#step-2--connect-workers)
   - [Step 3 — Add Projects and Deploy](#step-3--add-projects-and-deploy)
 - [Production Setup](#production-setup)
-  - [Install as systemd Services](#install-as-systemd-services)
+  - [Install as OS Services](#install-as-os-services)
   - [Custom Storage Paths](#custom-storage-paths)
   - [Security](#security)
 - [CLI Reference](#cli-reference)
@@ -205,7 +205,7 @@ DotnetFleet has two layers of auto-discovery so you rarely need to type the coor
 fleet worker
 ```
 
-The worker reads `~/.fleet/coordinator/config.json` (or the systemd unit) and connects to `http://localhost:<port>` with the token already present on disk.
+The worker reads `~/.fleet/coordinator/config.json` (or the installed coordinator service) and connects to `http://localhost:<port>` with the token already present on disk.
 
 **Other machine on the LAN (token only):**
 
@@ -248,21 +248,25 @@ To auto-deploy on new commits, set a **polling interval** (in minutes) on the pr
 
 ## Production Setup
 
-### Install as systemd Services
+### Install as OS Services
 
-For production, install the coordinator and workers as **systemd services** so they start on boot and restart on failure.
+For production, install the coordinator and workers as OS services so they start on boot and restart on failure. Linux uses **systemd**; Windows uses native **Windows Services**.
 
 You have two equivalent ways to install. Pick whichever you prefer.
 
 #### Option A — Zero-install (recommended for first-time setup)
 
-If you just installed .NET and don't yet have anything else, you can do the whole thing in one command using `dnx` (.NET 10's tool runner). **You don't need `sudo` — the tool re-executes itself under `sudo` automatically**, preserving `PATH`, `DOTNET_ROOT` and `HOME` so root can still find your per-user .NET install:
+If you just installed .NET and don't yet have anything else, you can do the whole thing in one command using `dnx` (.NET 10's tool runner).
+
+On Linux, you don't need `sudo` — the tool re-executes itself under `sudo` automatically, preserving `PATH`, `DOTNET_ROOT` and `HOME` so root can still find your per-user .NET install. On Windows, run the command from an elevated Administrator PowerShell or terminal:
 
 ```bash
 dnx dotnetfleet.tool coordinator install --port 5000
 ```
 
-You'll be prompted once for your sudo password. The first time you do this, the installer also detects it's running from `dnx`'s ephemeral cache and **automatically performs `dotnet tool install -g DotnetFleet.Tool`** for the calling user, so the systemd unit's `ExecStart=` points at the stable global-tool path (`~/.dotnet/tools/fleet`) instead of a cache location that may disappear later.
+On Linux, you'll be prompted once for your sudo password. The first time you do this, the installer also detects it's running from `dnx`'s ephemeral cache and **automatically performs `dotnet tool install -g DotnetFleet.Tool`** for the calling user, so the systemd unit's `ExecStart=` points at the stable global-tool path (`~/.dotnet/tools/fleet`) instead of a cache location that may disappear later.
+
+On Windows, the installer uses a service-local tool path under `%ProgramData%\DotnetFleet\tools`, so services do not depend on a user's profile or `dnx` cache.
 
 A worker on the same machine looks the same — and thanks to local auto-discovery you don't need `--coordinator` or `--token`:
 
@@ -282,7 +286,7 @@ dnx dotnetfleet.tool worker install --token <token> --name build-01
 # One-time:
 dotnet tool install -g DotnetFleet.Tool
 
-# Then (no sudo needed — fleet re-execs itself with sudo when required):
+# Then (Linux: no sudo needed because fleet re-execs itself; Windows: run elevated):
 fleet coordinator install --port 5000
 
 # Worker on the same machine — auto-discovered:
@@ -302,11 +306,11 @@ fleet worker install --token <token> --name build-01
 #### Managing the services
 
 ```bash
-# Status
+# Linux status
 sudo systemctl status fleet-coordinator
 sudo systemctl status fleet-worker-build-01
 
-# Logs
+# Linux logs
 journalctl -u fleet-coordinator -f
 journalctl -u fleet-worker-build-01 -f
 
@@ -318,18 +322,37 @@ fleet coordinator uninstall
 fleet worker uninstall --name build-01
 ```
 
-The services run as the calling user (via `SUDO_USER`), write unit files to `/etc/systemd/system/`, and use these service names:
+```powershell
+# Windows status
+Get-Service fleet-coordinator
+Get-Service fleet-worker-build-01
+
+# Windows stop/start
+Stop-Service fleet-coordinator
+Start-Service fleet-coordinator
+
+# Update tool + restart all local fleet services (run elevated)
+fleet update
+
+# Uninstall (run elevated)
+fleet coordinator uninstall
+fleet worker uninstall --name build-01
+```
+
+On Linux, services run as the calling user (via `SUDO_USER`) and write unit files to `/etc/systemd/system/`. On Windows, services run under LocalSystem and store the service-local tool under `%ProgramData%\DotnetFleet\tools`.
+
+Both platforms use these service names:
 
 | Component | Service name |
 |---|---|
 | Coordinator | `fleet-coordinator` |
 | Worker | `fleet-worker-{name}` |
 
-> **Note:** Service installation requires Linux with systemd. On other platforms, use the foreground commands with a process manager of your choice (e.g., `launchd`, `sc.exe`, or Docker).
+> **Note:** Native service installation is supported on Linux with systemd and Windows Services. On other platforms, use the foreground commands with a process manager of your choice (e.g., `launchd` or Docker).
 
 ### Custom Storage Paths
 
-By default, each component stores data under `~/.fleet/`:
+Foreground commands store data under `~/.fleet/` by default. Installed Linux services use the same user-home layout; installed Windows services default to `%ProgramData%\DotnetFleet\...`.
 
 | Component | Default path |
 |---|---|
@@ -341,7 +364,7 @@ You can redirect **everything** to a different location with `--data-dir`:
 
 ```bash
 # Store repos on an external drive
-sudo fleet worker install \
+fleet worker install \
   --coordinator http://myserver:5000 \
   --token <token> \
   --name build-01 \
@@ -383,13 +406,13 @@ Upgrading DotnetFleet replaces only the tool binary — **all data is preserved*
 
 #### One-shot update
 
-If the coordinator and/or workers run as systemd services on this machine, a single command updates the global tool and restarts every local fleet service:
+If the coordinator and/or workers run as installed services on this machine, a single command updates the service tool and restarts every local fleet service:
 
 ```bash
 fleet update
 ```
 
-`fleet update` (with no `sudo`) re-executes itself with `sudo` automatically, preserving `PATH`, `DOTNET_ROOT` and `HOME`. You'll be prompted for your password once.
+On Linux, `fleet update` (with no `sudo`) re-executes itself with `sudo` automatically, preserving `PATH`, `DOTNET_ROOT` and `HOME`. You'll be prompted for your password once. On Windows, run it from an elevated Administrator terminal.
 
 Options:
 
@@ -410,21 +433,32 @@ sudo systemctl restart fleet-coordinator
 sudo systemctl restart fleet-worker-<name>
 ```
 
-> The systemd unit files point at the **global tool** (`~/.dotnet/tools/fleet`) — there's no need to re-run `install` after a tool update.
+On Windows:
+
+```powershell
+Stop-Service fleet-coordinator
+Stop-Service fleet-worker-<name>
+dotnet tool update --tool-path "$env:ProgramData\DotnetFleet\tools" DotnetFleet.Tool
+fleet version   # verify the new version
+Start-Service fleet-coordinator
+Start-Service fleet-worker-<name>
+```
+
+> Linux systemd unit files point at the **global tool** (`~/.dotnet/tools/fleet`), and Windows services point at the service-local tool under `%ProgramData%\DotnetFleet\tools`. There's no need to re-run `install` after a tool update.
 
 #### What is preserved across upgrades
 
 | Component | Persisted data | Location |
 |---|---|---|
-| Coordinator | SQLite database (projects, jobs, history), `config.json` (JWT secret, registration token) | `~/.fleet/coordinator/` |
-| Worker | `worker.json` (id + secret), cached git repos | `~/.fleet/worker-{name}/` |
+| Coordinator | SQLite database (projects, jobs, history), `config.json` (JWT secret, registration token) | `~/.fleet/coordinator/` or `%ProgramData%\DotnetFleet\coordinator\` for Windows services |
+| Worker | `worker.json` (id + secret), cached git repos | `~/.fleet/worker-{name}/` or `%ProgramData%\DotnetFleet\worker-{name}\` for Windows services |
 
 #### Rollback
 
 If something goes wrong, downgrade to a specific version:
 
 ```bash
-sudo fleet update --version <previous-version>
+fleet update --version <previous-version>
 ```
 
 ---
@@ -433,8 +467,8 @@ sudo fleet update --version <previous-version>
 
 ```
 fleet coordinator [options]            Run coordinator in foreground
-fleet coordinator install [options]    Install as systemd service (sudo)
-fleet coordinator uninstall            Remove systemd service (sudo)
+fleet coordinator install [options]    Install as OS service
+fleet coordinator uninstall            Remove OS service
 fleet coordinator status               Show service status
 
   --port, -p <port>             HTTP port (default: 5000)
@@ -446,8 +480,8 @@ fleet coordinator status               Show service status
   --no-mdns                     Disable mDNS advertising on the LAN
 
 fleet worker [options]                 Run worker in foreground
-fleet worker install [options]         Install as systemd service (sudo)
-fleet worker uninstall [--name <n>]    Remove systemd service (sudo)
+fleet worker install [options]         Install as OS service
+fleet worker uninstall [--name <n>]    Remove OS service
 fleet worker status [--name <n>]       Show service status
 
   --coordinator, -c <url>       Coordinator URL (auto-discovered if omitted)
@@ -460,7 +494,7 @@ fleet worker status [--name <n>]       Show service status
 
 fleet version                          Show version
 
-fleet update [options]                 Update tool + restart local services (sudo)
+fleet update [options]                 Update tool + restart local services
   --skip-tool-update            Only restart services
   --version <version>           Pin a specific DotnetFleet.Tool version
   --prerelease                  Allow prerelease versions

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -12,7 +12,7 @@ revisa el [README](../README.md) o abre una issue.
 - [Instalación y arranque](#instalación-y-arranque)
 - [Tokens, secretos y credenciales](#tokens-secretos-y-credenciales)
 - [Workers y descubrimiento](#workers-y-descubrimiento)
-- [Servicios systemd: instalación, gestión y actualización](#servicios-systemd-instalación-gestión-y-actualización)
+- [Servicios: instalación, gestión y actualización](#servicios-instalación-gestión-y-actualización)
 - [Datos, almacenamiento y caché](#datos-almacenamiento-y-caché)
 - [Actualizaciones y rollback](#actualizaciones-y-rollback)
 - [Seguridad y red](#seguridad-y-red)
@@ -54,8 +54,8 @@ raíz y pulsa **Deploy Now**.
 
 ### Y para producción
 
-Para que arranquen en boot y se reinicien al fallar, instala como servicios
-systemd. Salta a [Servicios systemd](#servicios-systemd-instalación-gestión-y-actualización).
+Para que arranquen en boot y se reinicien al fallar, instala como servicios.
+Salta a [Servicios](#servicios-instalación-gestión-y-actualización).
 
 ---
 
@@ -64,26 +64,27 @@ systemd. Salta a [Servicios systemd](#servicios-systemd-instalación-gestión-y-
 ### ¿Qué necesito instalado para usar DotnetFleet?
 
 .NET 10 SDK (para `dnx`) o tener instalada la herramienta global
-`DotnetFleet.Tool`. En Linux, además, `systemd` si quieres registrar
-coordinador/worker como servicios. Los repos que despliegues solo necesitan
+`DotnetFleet.Tool`. En Linux necesitas `systemd` si quieres registrar
+coordinador/worker como servicios; en Windows necesitas una terminal elevada
+para crear Windows Services. Los repos que despliegues solo necesitan
 `deployer.yaml` en la raíz (el worker invoca `dnx dotnetdeployer.tool -y`, que
 se descarga sola).
 
 ### ¿Tengo que instalar la tool globalmente o puedo usar `dnx` siempre?
 
-Para uso puntual basta `dnx dotnetfleet.tool ...`. Para servicios de systemd
-**sí** se requiere la global tool (`~/.dotnet/tools/fleet`), porque la unidad
-necesita un `ExecStart=` con ruta estable. Si llamas a `coordinator install` o
-`worker install` desde `dnx`, la propia herramienta detecta esa situación e
-instala la global tool por ti.
+Para uso puntual basta `dnx dotnetfleet.tool ...`. Para servicios instalados
+sí se requiere una ruta estable. En Linux la herramienta usa la global tool
+(`~/.dotnet/tools/fleet`); en Windows instala una copia de herramienta bajo
+`%ProgramData%\DotnetFleet\tools`. Si llamas a `coordinator install` o
+`worker install` desde `dnx`, la propia herramienta prepara esa ruta estable.
 
 ### ¿Funciona en Windows o macOS?
 
 El comando en primer plano (`fleet coordinator` / `fleet worker`) es
 multiplataforma. La instalación como servicio (`install` / `uninstall` /
-`status`) es por ahora **solo Linux + systemd**. En otros sistemas usa el
-gestor que prefieras (NSSM, launchd, Docker, etc.) apuntando a `fleet
-coordinator`.
+`status`) funciona en Linux + systemd y en Windows Services. En macOS o en
+Linux sin systemd, usa el gestor que prefieras (`launchd`, Docker, etc.)
+apuntando a `fleet coordinator`.
 
 ---
 
@@ -100,16 +101,18 @@ cat ~/.fleet/coordinator/config.json
 
 Busca el campo `registrationToken`. Si arrancaste con un `--data-dir` distinto,
 el archivo está en `<data-dir>/config.json`. Si el coordinador corre como
-servicio systemd lanzado con `sudo`, la herramienta resuelve el home del
-usuario original vía `SUDO_USER`, así que sigue estando bajo
-`~/.fleet/coordinator/`.
+servicio Linux, la herramienta resuelve el home del usuario original vía
+`SUDO_USER`, así que sigue estando bajo `~/.fleet/coordinator/`. En Windows
+Services, por defecto vive bajo `%ProgramData%\DotnetFleet\coordinator\`.
 
 También aparece en el banner que imprime `fleet coordinator` al arrancar; si se
-ejecuta como servicio, puedes verlo con:
+ejecuta como servicio Linux, puedes verlo con:
 
 ```bash
 journalctl -u fleet-coordinator --no-pager | grep -i token
 ```
+
+En Windows Services, lee el `config.json` del `data-dir` del coordinador.
 
 ### ¿Puedo fijar yo el token en lugar de uno aleatorio?
 
@@ -136,7 +139,7 @@ secreto persistente al siguiente latido.
 ```bash
 fleet coordinator --admin-password <nueva-contraseña>
 # o, si está como servicio:
-sudo fleet coordinator install --admin-password <nueva-contraseña>
+fleet coordinator install --admin-password <nueva-contraseña>
 ```
 
 ### ¿Dónde se guardan las credenciales del worker?
@@ -152,8 +155,8 @@ worker.
 
 ### Tengo el coordinador y el worker en la **misma máquina**. ¿Necesito pasar URL y token?
 
-No. `fleet worker` lee `~/.fleet/coordinator/config.json` (o la unidad systemd
-del coordinador) y se conecta a `http://localhost:<puerto>` con el token ya
+No. `fleet worker` lee `~/.fleet/coordinator/config.json` (o el servicio
+instalado del coordinador) y se conecta a `http://localhost:<puerto>` con el token ya
 encontrado en disco.
 
 ### Y en la **misma LAN** pero distintas máquinas?
@@ -195,7 +198,7 @@ Cada 10 s por defecto. Ajustable con `--poll-interval <segundos>`.
 
 ---
 
-## Servicios systemd: instalación, gestión y actualización
+## Servicios: instalación, gestión y actualización
 
 ### ¿Cómo se llaman los servicios?
 
@@ -204,9 +207,12 @@ Cada 10 s por defecto. Ajustable con `--poll-interval <segundos>`.
 | Coordinador | `fleet-coordinator`       |
 | Worker      | `fleet-worker-{nombre}`   |
 
-Las unidades viven en `/etc/systemd/system/` y corren bajo el usuario que
-invocó el `install` (resuelto vía `SUDO_USER`). Apuntan al binario estable
+En Linux, las unidades viven en `/etc/systemd/system/` y corren bajo el usuario
+que invocó el `install` (resuelto vía `SUDO_USER`). Apuntan al binario estable
 `~/.dotnet/tools/fleet`, no a rutas efímeras de `dnx`.
+
+En Windows, los servicios se registran en el Service Control Manager, corren
+bajo LocalSystem y apuntan a `%ProgramData%\DotnetFleet\tools\fleet.exe`.
 
 ### Instalación recomendada
 
@@ -214,8 +220,8 @@ invocó el `install` (resuelto vía `SUDO_USER`). Apuntan al binario estable
 
 ```bash
 fleet coordinator install --port 5000
-#  → te pide la contraseña de sudo una vez
-#  → instala /etc/systemd/system/fleet-coordinator.service
+#  → Linux: te pide la contraseña de sudo una vez
+#  → Windows: ejecútalo en una terminal elevada
 #  → arranca y habilita el servicio
 ```
 
@@ -245,6 +251,8 @@ fleet worker install \
 > sirve.
 
 ### ¿Por qué no debo poner `sudo` delante de `fleet`?
+
+Esto solo aplica a Linux.
 
 `sudo` resetea `PATH` al `secure_path` de `/etc/sudoers`, que **no incluye
 `~/.dotnet/tools`**. Resultado: `sudo: fleet: orden no encontrada`. La
@@ -283,6 +291,8 @@ home y verás:
 
 ### Gestión diaria de los servicios
 
+Linux:
+
 ```bash
 # Estado y logs
 sudo systemctl status fleet-coordinator
@@ -299,21 +309,35 @@ fleet coordinator uninstall
 fleet worker uninstall --name build-01
 ```
 
+Windows:
+
+```powershell
+# Estado
+Get-Service fleet-coordinator
+Get-Service fleet-worker-build-01
+
+# Reinicio
+Restart-Service fleet-coordinator
+Restart-Service fleet-worker-build-01
+
+# Desinstalación (terminal elevada)
+fleet coordinator uninstall
+fleet worker uninstall --name build-01
+```
+
 ### Actualización en sitio (one-shot)
 
-Para actualizar la global tool **y** reiniciar todos los servicios fleet
+Para actualizar la herramienta de servicio **y** reiniciar todos los servicios fleet
 locales en una sola orden:
 
 ```bash
 fleet update
-#  → se autoeleva con sudo (te pide contraseña una vez)
-#  → dotnet tool update -g DotnetFleet.Tool
-#  → systemctl restart fleet-coordinator + cada fleet-worker-*
-#  → preserva PATH, DOTNET_ROOT y HOME
+#  → Linux: se autoeleva con sudo y reinicia con systemctl
+#  → Windows: ejecútalo en una terminal elevada y reinicia Windows Services
 ```
 
-No hace falta reinstalar las unidades systemd después: apuntan a la ruta
-estable `~/.dotnet/tools/fleet`, así que basta con reiniciar.
+No hace falta reinstalar los servicios después: apuntan a una ruta estable, así
+que basta con reiniciar.
 
 ### Actualización manual (si prefieres control fino)
 
@@ -321,6 +345,16 @@ estable `~/.dotnet/tools/fleet`, así que basta con reiniciar.
 dotnet tool update -g DotnetFleet.Tool
 sudo systemctl restart fleet-coordinator
 sudo systemctl restart fleet-worker-<nombre>
+```
+
+En Windows:
+
+```powershell
+Stop-Service fleet-coordinator
+Stop-Service fleet-worker-<nombre>
+dotnet tool update --tool-path "$env:ProgramData\DotnetFleet\tools" DotnetFleet.Tool
+Start-Service fleet-coordinator
+Start-Service fleet-worker-<nombre>
 ```
 
 ### Rollback a una versión anterior
@@ -331,15 +365,25 @@ sudo systemctl restart fleet-coordinator
 sudo systemctl restart fleet-worker-<nombre>
 ```
 
+En Windows:
+
+```powershell
+Stop-Service fleet-coordinator
+Stop-Service fleet-worker-<nombre>
+dotnet tool update --tool-path "$env:ProgramData\DotnetFleet\tools" DotnetFleet.Tool --version <versión-anterior>
+Start-Service fleet-coordinator
+Start-Service fleet-worker-<nombre>
+```
+
 Todos los datos (`~/.fleet/`) se preservan: proyectos, jobs, historial,
 `config.json`, credenciales de worker y caché de repos.
 
-### ¿Y si no estoy en Linux con systemd?
+### ¿Y si no estoy en Linux con systemd ni Windows?
 
-Los `install` solo funcionan en Linux con systemd. En Windows / macOS / sin
-systemd, ejecuta el coordinador y los workers en primer plano (`fleet
-coordinator`, `fleet worker`) bajo el gestor que prefieras: `launchd`, NSSM,
-`sc.exe`, Docker, etc.
+Los `install` nativos funcionan en Linux con systemd y Windows Services. En
+macOS o Linux sin systemd, ejecuta el coordinador y los workers en primer
+plano (`fleet coordinator`, `fleet worker`) bajo el gestor que prefieras:
+`launchd`, Docker, etc.
 
 ---
 
@@ -349,8 +393,8 @@ coordinator`, `fleet worker`) bajo el gestor que prefieras: `launchd`, NSSM,
 
 | Componente  | Contenido                                                     | Ruta por defecto                |
 |-------------|---------------------------------------------------------------|---------------------------------|
-| Coordinador | SQLite (proyectos, jobs, historial), `config.json`            | `~/.fleet/coordinator/`         |
-| Worker      | `worker.json` (id + secreto), repos clonados, caché LRU       | `~/.fleet/worker-{nombre}/`     |
+| Coordinador | SQLite (proyectos, jobs, historial), `config.json`            | `~/.fleet/coordinator/` o `%ProgramData%\DotnetFleet\coordinator\` en Windows Services |
+| Worker      | `worker.json` (id + secreto), repos clonados, caché LRU       | `~/.fleet/worker-{nombre}/` o `%ProgramData%\DotnetFleet\worker-{nombre}\` en Windows Services |
 
 Cambia la ubicación con `--data-dir`. Útil, por ejemplo, para mover la caché
 de repos a un disco externo:
@@ -374,8 +418,8 @@ para otras bases de datos hoy.
 
 Copiar dos directorios basta:
 
-- **Coordinador:** todo `~/.fleet/coordinator/` (DB + `config.json`).
-- **Workers:** `~/.fleet/worker-{nombre}/worker.json` (las credenciales). El
+- **Coordinador:** todo el `data-dir` del coordinador (DB + `config.json`).
+- **Workers:** el `worker.json` dentro del `data-dir` del worker. El
   caché de repos no es crítico — se reconstruye solo.
 
 ### ¿Las migraciones de esquema son automáticas?
@@ -390,20 +434,23 @@ migraciones manuales con `ALTER TABLE` protegidas por checks sobre
 
 ### ¿Cómo actualizo a una versión nueva?
 
-Una sola orden actualiza la global tool **y** reinicia todos los servicios
+Una sola orden actualiza la herramienta de servicio **y** reinicia todos los servicios
 fleet locales:
 
 ```bash
 fleet update
 ```
 
-Reejecuta con `sudo` automáticamente y preserva `PATH`/`DOTNET_ROOT`/`HOME`.
+En Linux se reejecuta con `sudo` automáticamente y preserva
+`PATH`/`DOTNET_ROOT`/`HOME`. En Windows hay que lanzarlo desde una terminal
+elevada.
 
 ### ¿Tengo que reinstalar los servicios después de actualizar?
 
-No. Las unidades systemd apuntan a `~/.dotnet/tools/fleet` (la global tool), que
-queda en la misma ruta tras actualizar. Basta con `systemctl restart`, que es
-lo que `fleet update` ya hace.
+No. Las unidades systemd apuntan a `~/.dotnet/tools/fleet` y los Windows
+Services apuntan a `%ProgramData%\DotnetFleet\tools\fleet.exe`. Esas rutas no
+cambian al actualizar; basta con reiniciar los servicios, que es lo que
+`fleet update` ya hace.
 
 ### ¿Pierdo proyectos, jobs o historial al actualizar?
 
@@ -417,6 +464,16 @@ worker, caché de repos) se conserva.
 dotnet tool update -g DotnetFleet.Tool --version <versión-anterior>
 sudo systemctl restart fleet-coordinator
 sudo systemctl restart fleet-worker-<nombre>
+```
+
+En Windows:
+
+```powershell
+Stop-Service fleet-coordinator
+Stop-Service fleet-worker-<nombre>
+dotnet tool update --tool-path "$env:ProgramData\DotnetFleet\tools" DotnetFleet.Tool --version <versión-anterior>
+Start-Service fleet-coordinator
+Start-Service fleet-worker-<nombre>
 ```
 
 ---
@@ -494,11 +551,13 @@ auto-recuperación, no un error.
 
 ### Cambié el puerto del coordinador y los workers ya no se conectan
 
-Si los workers usaron auto-descubrimiento local, releen el `config.json` /
-unidad systemd y se actualizan solos. Si tenían `--coordinator` fijo, hay que
+Si los workers usaron auto-descubrimiento local, releen el `config.json` o el
+servicio instalado y se actualizan solos. Si tenían `--coordinator` fijo, hay que
 actualizarlo (o reinstalar el servicio del worker con la nueva URL).
 
 ### `sudo fleet ...` me dice `sudo: fleet: orden no encontrada`
+
+Esto solo aplica a Linux.
 
 `sudo` resetea el `PATH` al `secure_path` de `/etc/sudoers`, donde
 `~/.dotnet/tools` no está incluido. Tres formas de arreglarlo:
@@ -546,7 +605,7 @@ Comprueba:
    y preserva `PATH`/`DOTNET_ROOT`/`HOME`. `sudo fleet ...` falla porque
    `~/.dotnet/tools` no está en `secure_path` (ver pregunta anterior). Si la
    autoelevación no funciona en tu entorno, usa el workaround de la
-   [sección systemd](#y-si-la-autoelevación-no-funciona).
+   [sección de servicios](#y-si-la-autoelevación-no-funciona).
 3. **Versión < 0.0.36 con `install`.** Hubo un bug en `SudoElevation` que al
    reejecutarse con `sudo` añadía el path de la DLL como argumento, dando
    `Comando o argumento no reconocido '/home/.../DotnetFleet.Tool.dll'`.

--- a/src/DotnetFleet.Coordinator/CoordinatorHostBuilder.cs
+++ b/src/DotnetFleet.Coordinator/CoordinatorHostBuilder.cs
@@ -34,11 +34,25 @@ public static class CoordinatorHostBuilder
         options ??= new CoordinatorStartupOptions();
 
         var builder = WebApplication.CreateBuilder(args);
-        builder.Host.UseSerilog((ctx, services, lc) => lc
-            .ReadFrom.Configuration(ctx.Configuration)
-            .ReadFrom.Services(services)
-            .Enrich.FromLogContext()
-            .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"));
+
+        builder.Services.AddWindowsService(serviceOptions =>
+        {
+            serviceOptions.ServiceName = "DotnetFleet Coordinator";
+        });
+
+        var logPath = ResolveLogPath(options.DataDir);
+        var logDir = Path.GetDirectoryName(logPath);
+        if (!string.IsNullOrEmpty(logDir))
+            Directory.CreateDirectory(logDir);
+
+        builder.Host.UseSerilog((ctx, services, lc) =>
+        {
+            lc.ReadFrom.Configuration(ctx.Configuration)
+                .ReadFrom.Services(services)
+                .Enrich.FromLogContext()
+                .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
+                .WriteTo.File(logPath, rollingInterval: RollingInterval.Day, retainedFileCountLimit: 14);
+        });
 
         // Apply CLI overrides to configuration
         ApplyOverrides(builder.Configuration, options);
@@ -325,5 +339,12 @@ public static class CoordinatorHostBuilder
 
         if (overrides.Count > 0)
             config.AddInMemoryCollection(overrides);
+    }
+
+    internal static string ResolveLogPath(string? dataDir)
+    {
+        return string.IsNullOrEmpty(dataDir)
+            ? Path.Combine("logs", "coordinator-.log")
+            : Path.Combine(dataDir, "logs", "coordinator-.log");
     }
 }

--- a/src/DotnetFleet.Coordinator/DotnetFleet.Coordinator.csproj
+++ b/src/DotnetFleet.Coordinator/DotnetFleet.Coordinator.csproj
@@ -14,8 +14,10 @@
     <PackageReference Include="BCrypt.Net-Next" />
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="Serilog.Extensions.Hosting" />
     <PackageReference Include="Serilog.Settings.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
     <PackageReference Include="Makaretu.Dns.Multicast.New" />
     <PackageReference Include="YamlDotNet" />
   </ItemGroup>

--- a/src/DotnetFleet.Tool/LocalCoordinatorDiscovery.cs
+++ b/src/DotnetFleet.Tool/LocalCoordinatorDiscovery.cs
@@ -55,16 +55,21 @@ public static class LocalCoordinatorDiscovery
     public static Result? TryFromUserHome()
     {
         var homes = new List<string>();
-        var sudoUser = Environment.GetEnvironmentVariable("SUDO_USER");
-        if (!string.IsNullOrEmpty(sudoUser))
+        var comparer = OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
+        void AddHome(string? home)
         {
-            var home = ResolveUserHome(sudoUser);
-            if (home != null) homes.Add(home);
+            if (!string.IsNullOrWhiteSpace(home) && !homes.Any(existing => comparer.Equals(existing, home)))
+                homes.Add(home);
         }
 
-        var currentHome = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        if (!string.IsNullOrEmpty(currentHome) && !homes.Contains(currentHome))
-            homes.Add(currentHome);
+        var sudoUser = Environment.GetEnvironmentVariable("SUDO_USER");
+        if (!string.IsNullOrEmpty(sudoUser))
+            AddHome(ResolveUserHome(sudoUser));
+
+        AddHome(Environment.GetEnvironmentVariable("HOME"));
+        AddHome(Environment.GetEnvironmentVariable("USERPROFILE"));
+        AddHome(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
 
         foreach (var home in homes)
         {

--- a/src/DotnetFleet.Tool/LocalCoordinatorDiscovery.cs
+++ b/src/DotnetFleet.Tool/LocalCoordinatorDiscovery.cs
@@ -8,9 +8,10 @@ namespace DotnetFleet.Tool;
 /// secrets between commands.
 ///
 /// Discovery order:
-///   1. systemd unit at /etc/systemd/system/fleet-coordinator.service
-///        → parse WorkingDirectory= → load &lt;dir&gt;/config.json
-///   2. ~/.fleet/coordinator/config.json for the effective user (SUDO_USER or current)
+///   1. Installed OS service
+///        → systemd WorkingDirectory= or Windows ImagePath --data-dir → load &lt;dir&gt;/config.json
+///   2. Platform service data dir
+///   3. ~/.fleet/coordinator/config.json for the effective user (SUDO_USER or current)
 /// </summary>
 public static class LocalCoordinatorDiscovery
 {
@@ -20,7 +21,23 @@ public static class LocalCoordinatorDiscovery
 
     public static Result? TryDiscover()
     {
+        if (OperatingSystem.IsWindows())
+        {
+            return WindowsServiceManager.TryDiscoverCoordinatorFromInstalledService()
+                   ?? TryFromWindowsProgramData()
+                   ?? TryFromUserHome();
+        }
+
         return TryFromSystemdUnit() ?? TryFromUserHome();
+    }
+
+    public static Result? TryFromWindowsProgramData()
+    {
+        if (!OperatingSystem.IsWindows())
+            return null;
+
+        var dataDir = WindowsServiceManager.GetDefaultWindowsDataDir("coordinator");
+        return TryLoadFromDataDir(dataDir, source: $"{Path.Combine(dataDir, "config.json")}");
     }
 
     public static Result? TryFromSystemdUnit()
@@ -59,7 +76,7 @@ public static class LocalCoordinatorDiscovery
         return null;
     }
 
-    private static Result? TryLoadFromDataDir(string dataDir, string source)
+    internal static Result? TryLoadFromDataDir(string dataDir, string source)
     {
         var configPath = Path.Combine(dataDir, "config.json");
         if (!File.Exists(configPath))

--- a/src/DotnetFleet.Tool/Program.cs
+++ b/src/DotnetFleet.Tool/Program.cs
@@ -100,7 +100,7 @@ coordinatorCommand.SetAction(async (parseResult, cancellationToken) =>
 });
 
 // ── fleet coordinator install ────────────────────────────────────────────
-var coordInstallCommand = new Command("install", "Install coordinator as a systemd service");
+var coordInstallCommand = new Command("install", "Install coordinator as an OS service");
 coordInstallCommand.Options.Add(portOption);
 coordInstallCommand.Options.Add(coordDataDirOption);
 coordInstallCommand.Options.Add(tokenOption);
@@ -115,7 +115,7 @@ coordInstallCommand.SetAction(async (parseResult, _) =>
     if (elevated.HasValue) Environment.Exit(elevated.Value);
 
     var port = parseResult.GetValue(portOption);
-    var dataDir = parseResult.GetValue(coordDataDirOption) ?? FleetConfig.GetDefaultDataDir("coordinator");
+    var dataDir = parseResult.GetValue(coordDataDirOption) ?? ServiceInstaller.GetDefaultInstallDataDir("coordinator");
     await ServiceInstaller.InstallCoordinatorAsync(new ServiceInstaller.CoordinatorInstallOptions(
         Port: port,
         DataDir: dataDir,
@@ -127,7 +127,7 @@ coordInstallCommand.SetAction(async (parseResult, _) =>
 });
 
 // ── fleet coordinator uninstall ──────────────────────────────────────────
-var coordUninstallCommand = new Command("uninstall", "Remove the coordinator systemd service");
+var coordUninstallCommand = new Command("uninstall", "Remove the coordinator OS service");
 coordUninstallCommand.SetAction(async (_, _) =>
 {
     var elevated = SudoElevation.ReExecAsRootIfNeeded();
@@ -243,7 +243,7 @@ workerCommand.SetAction(async (parseResult, cancellationToken) =>
 });
 
 // ── fleet worker install ─────────────────────────────────────────────────
-var workerInstallCommand = new Command("install", "Install worker as a systemd service");
+var workerInstallCommand = new Command("install", "Install worker as an OS service");
 workerInstallCommand.Options.Add(coordinatorUrlOption);
 workerInstallCommand.Options.Add(workerTokenOption);
 workerInstallCommand.Options.Add(nameOption);
@@ -259,7 +259,7 @@ workerInstallCommand.SetAction(async (parseResult, _) =>
 
     var workerName = parseResult.GetValue(nameOption) ?? Environment.MachineName;
     var dataDir = parseResult.GetValue(workerDataDirOption)
-                  ?? FleetConfig.GetDefaultDataDir($"worker-{workerName}");
+                  ?? ServiceInstaller.GetDefaultInstallDataDir($"worker-{workerName}");
     var explicitUrl = parseResult.GetValue(coordinatorUrlOption);
     var explicitToken = parseResult.GetValue(workerTokenOption);
     var noDiscover = parseResult.GetValue(noDiscoverOption);
@@ -278,7 +278,7 @@ workerInstallCommand.SetAction(async (parseResult, _) =>
 });
 
 // ── fleet worker uninstall ───────────────────────────────────────────────
-var workerUninstallCommand = new Command("uninstall", "Remove a worker systemd service");
+var workerUninstallCommand = new Command("uninstall", "Remove a worker OS service");
 var uninstallNameOption = new Option<string?>("--name", "-n")
 {
     Description = "Worker name to uninstall (default: hostname)"

--- a/src/DotnetFleet.Tool/Program.cs
+++ b/src/DotnetFleet.Tool/Program.cs
@@ -111,29 +111,45 @@ coordInstallCommand.Options.Add(noMdnsOption);
 
 coordInstallCommand.SetAction(async (parseResult, _) =>
 {
-    var elevated = SudoElevation.ReExecAsRootIfNeeded();
-    if (elevated.HasValue) Environment.Exit(elevated.Value);
+    try
+    {
+        var elevated = SudoElevation.ReExecAsRootIfNeeded();
+        if (elevated.HasValue) return elevated.Value;
 
-    var port = parseResult.GetValue(portOption);
-    var dataDir = parseResult.GetValue(coordDataDirOption) ?? ServiceInstaller.GetDefaultInstallDataDir("coordinator");
-    await ServiceInstaller.InstallCoordinatorAsync(new ServiceInstaller.CoordinatorInstallOptions(
-        Port: port,
-        DataDir: dataDir,
-        Token: parseResult.GetValue(tokenOption),
-        JwtSecret: parseResult.GetValue(jwtSecretOption),
-        AdminPassword: parseResult.GetValue(adminPasswordOption),
-        Urls: parseResult.GetValue(urlsOption),
-        NoMdns: parseResult.GetValue(noMdnsOption)));
+        var port = parseResult.GetValue(portOption);
+        var dataDir = parseResult.GetValue(coordDataDirOption) ?? ServiceInstaller.GetDefaultInstallDataDir("coordinator");
+        await ServiceInstaller.InstallCoordinatorAsync(new ServiceInstaller.CoordinatorInstallOptions(
+            Port: port,
+            DataDir: dataDir,
+            Token: parseResult.GetValue(tokenOption),
+            JwtSecret: parseResult.GetValue(jwtSecretOption),
+            AdminPassword: parseResult.GetValue(adminPasswordOption),
+            Urls: parseResult.GetValue(urlsOption),
+            NoMdns: parseResult.GetValue(noMdnsOption)));
+        return 0;
+    }
+    catch (UnauthorizedAccessException)
+    {
+        return 1;
+    }
 });
 
 // ── fleet coordinator uninstall ──────────────────────────────────────────
 var coordUninstallCommand = new Command("uninstall", "Remove the coordinator OS service");
 coordUninstallCommand.SetAction(async (_, _) =>
 {
-    var elevated = SudoElevation.ReExecAsRootIfNeeded();
-    if (elevated.HasValue) Environment.Exit(elevated.Value);
+    try
+    {
+        var elevated = SudoElevation.ReExecAsRootIfNeeded();
+        if (elevated.HasValue) return elevated.Value;
 
-    await ServiceInstaller.UninstallCoordinatorAsync();
+        await ServiceInstaller.UninstallCoordinatorAsync();
+        return 0;
+    }
+    catch (UnauthorizedAccessException)
+    {
+        return 1;
+    }
 });
 
 // ── fleet coordinator status ─────────────────────────────────────────────
@@ -254,27 +270,34 @@ workerInstallCommand.Options.Add(noDiscoverOption);
 
 workerInstallCommand.SetAction(async (parseResult, _) =>
 {
-    var elevated = SudoElevation.ReExecAsRootIfNeeded();
-    if (elevated.HasValue) return elevated.Value;
+    try
+    {
+        var elevated = SudoElevation.ReExecAsRootIfNeeded();
+        if (elevated.HasValue) return elevated.Value;
 
-    var workerName = parseResult.GetValue(nameOption) ?? Environment.MachineName;
-    var dataDir = parseResult.GetValue(workerDataDirOption)
-                  ?? ServiceInstaller.GetDefaultInstallDataDir($"worker-{workerName}");
-    var explicitUrl = parseResult.GetValue(coordinatorUrlOption);
-    var explicitToken = parseResult.GetValue(workerTokenOption);
-    var noDiscover = parseResult.GetValue(noDiscoverOption);
+        var workerName = parseResult.GetValue(nameOption) ?? Environment.MachineName;
+        var dataDir = parseResult.GetValue(workerDataDirOption)
+                      ?? ServiceInstaller.GetDefaultInstallDataDir($"worker-{workerName}");
+        var explicitUrl = parseResult.GetValue(coordinatorUrlOption);
+        var explicitToken = parseResult.GetValue(workerTokenOption);
+        var noDiscover = parseResult.GetValue(noDiscoverOption);
 
-    var resolved = await CoordinatorResolver.ResolveAsync(explicitUrl, explicitToken, noDiscover);
-    if (resolved == null) return 1;
+        var resolved = await CoordinatorResolver.ResolveAsync(explicitUrl, explicitToken, noDiscover);
+        if (resolved == null) return 1;
 
-    await ServiceInstaller.InstallWorkerAsync(new ServiceInstaller.WorkerInstallOptions(
-        CoordinatorUrl: resolved.Url,
-        Token: resolved.Token,
-        Name: workerName,
-        DataDir: dataDir,
-        PollInterval: parseResult.GetValue(pollIntervalOption),
-        MaxDisk: parseResult.GetValue(maxDiskOption)));
-    return 0;
+        await ServiceInstaller.InstallWorkerAsync(new ServiceInstaller.WorkerInstallOptions(
+            CoordinatorUrl: resolved.Url,
+            Token: resolved.Token,
+            Name: workerName,
+            DataDir: dataDir,
+            PollInterval: parseResult.GetValue(pollIntervalOption),
+            MaxDisk: parseResult.GetValue(maxDiskOption)));
+        return 0;
+    }
+    catch (UnauthorizedAccessException)
+    {
+        return 1;
+    }
 });
 
 // ── fleet worker uninstall ───────────────────────────────────────────────
@@ -286,11 +309,19 @@ var uninstallNameOption = new Option<string?>("--name", "-n")
 workerUninstallCommand.Options.Add(uninstallNameOption);
 workerUninstallCommand.SetAction(async (parseResult, _) =>
 {
-    var elevated = SudoElevation.ReExecAsRootIfNeeded();
-    if (elevated.HasValue) Environment.Exit(elevated.Value);
+    try
+    {
+        var elevated = SudoElevation.ReExecAsRootIfNeeded();
+        if (elevated.HasValue) return elevated.Value;
 
-    var workerName = parseResult.GetValue(uninstallNameOption) ?? Environment.MachineName;
-    await ServiceInstaller.UninstallWorkerAsync(workerName);
+        var workerName = parseResult.GetValue(uninstallNameOption) ?? Environment.MachineName;
+        await ServiceInstaller.UninstallWorkerAsync(workerName);
+        return 0;
+    }
+    catch (UnauthorizedAccessException)
+    {
+        return 1;
+    }
 });
 
 // ── fleet worker status ──────────────────────────────────────────────────

--- a/src/DotnetFleet.Tool/ServiceCommandLine.cs
+++ b/src/DotnetFleet.Tool/ServiceCommandLine.cs
@@ -1,0 +1,99 @@
+namespace DotnetFleet.Tool;
+
+internal static class ServiceCommandLine
+{
+    public static string BuildCoordinatorArgs(ServiceInstaller.CoordinatorInstallOptions opts)
+    {
+        var parts = new List<string>
+        {
+            $"--port {opts.Port}",
+            $"--data-dir {QuoteArgument(opts.DataDir)}"
+        };
+
+        if (opts.Token != null) parts.Add($"--token {QuoteArgument(opts.Token)}");
+        if (opts.JwtSecret != null) parts.Add($"--jwt-secret {QuoteArgument(opts.JwtSecret)}");
+        if (opts.AdminPassword != null) parts.Add($"--admin-password {QuoteArgument(opts.AdminPassword)}");
+        if (opts.Urls != null) parts.Add($"--urls {QuoteArgument(opts.Urls)}");
+        if (opts.NoMdns) parts.Add("--no-mdns");
+
+        return string.Join(" ", parts);
+    }
+
+    public static string BuildWorkerArgs(ServiceInstaller.WorkerInstallOptions opts)
+    {
+        var parts = new List<string>
+        {
+            $"--coordinator {QuoteArgument(opts.CoordinatorUrl)}",
+            $"--name {QuoteArgument(opts.Name)}",
+            $"--data-dir {QuoteArgument(opts.DataDir)}"
+        };
+
+        if (opts.Token != null) parts.Add($"--token {QuoteArgument(opts.Token)}");
+        if (opts.PollInterval.HasValue) parts.Add($"--poll-interval {opts.PollInterval}");
+        if (opts.MaxDisk.HasValue) parts.Add($"--max-disk {opts.MaxDisk}");
+
+        return string.Join(" ", parts);
+    }
+
+    public static string QuoteArgument(string value)
+    {
+        return "\"" + value.Replace("\"", "\\\"", StringComparison.Ordinal) + "\"";
+    }
+
+    public static IReadOnlyList<string> Split(string commandLine)
+    {
+        var args = new List<string>();
+        var current = new System.Text.StringBuilder();
+        var inQuotes = false;
+        for (var i = 0; i < commandLine.Length; i++)
+        {
+            var ch = commandLine[i];
+
+            if (ch == '\\' && inQuotes && i + 1 < commandLine.Length && commandLine[i + 1] == '"')
+            {
+                current.Append('"');
+                i++;
+                continue;
+            }
+
+            if (ch == '"')
+            {
+                inQuotes = !inQuotes;
+                continue;
+            }
+
+            if (char.IsWhiteSpace(ch) && !inQuotes)
+            {
+                AddCurrent();
+                continue;
+            }
+
+            current.Append(ch);
+        }
+
+        AddCurrent();
+        return args;
+
+        void AddCurrent()
+        {
+            if (current.Length == 0)
+                return;
+
+            args.Add(current.ToString());
+            current.Clear();
+        }
+    }
+
+    public static string? GetOptionValue(IReadOnlyList<string> args, string option)
+    {
+        for (var i = 0; i < args.Count; i++)
+        {
+            if (!string.Equals(args[i], option, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            return i + 1 < args.Count ? args[i + 1] : null;
+        }
+
+        return null;
+    }
+}

--- a/src/DotnetFleet.Tool/ServiceInstaller.cs
+++ b/src/DotnetFleet.Tool/ServiceInstaller.cs
@@ -4,8 +4,8 @@ using System.Runtime.InteropServices;
 namespace DotnetFleet.Tool;
 
 /// <summary>
-/// Installs, uninstalls and queries DotnetFleet services as system-level systemd services.
-/// Requires root (sudo) for install/uninstall. Services start automatically at boot.
+/// Installs, uninstalls and queries DotnetFleet services as OS services.
+/// Linux uses systemd; Windows uses the Service Control Manager.
 /// </summary>
 public static class ServiceInstaller
 {
@@ -17,6 +17,14 @@ public static class ServiceInstaller
     // ── Platform check ───────────────────────────────────────────────────────
 
     public static bool IsLinux => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+    public static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+    public static string GetDefaultInstallDataDir(string component)
+    {
+        return IsWindows
+            ? WindowsServiceManager.GetDefaultWindowsDataDir(component)
+            : FleetConfig.GetDefaultDataDir(component);
+    }
 
     [DllImport("libc")]
     private static extern uint geteuid();
@@ -25,7 +33,7 @@ public static class ServiceInstaller
     {
         if (!IsLinux)
             throw new PlatformNotSupportedException(
-                "Service installation is currently supported only on Linux (systemd). " +
+                "Service installation is supported on Linux (systemd) and Windows Services. " +
                 "On other platforms, run 'fleet coordinator' / 'fleet worker' in the foreground or use a process manager.");
     }
 
@@ -52,6 +60,12 @@ public static class ServiceInstaller
 
     public static async Task InstallCoordinatorAsync(CoordinatorInstallOptions opts)
     {
+        if (IsWindows)
+        {
+            await WindowsServiceManager.InstallCoordinatorAsync(opts);
+            return;
+        }
+
         EnsureLinux();
         EnsureRoot();
 
@@ -84,7 +98,7 @@ public static class ServiceInstaller
         Console.WriteLine($"    Data directory: {opts.DataDir}");
         Console.WriteLine();
         Console.WriteLine($"  Connect workers with:");
-        Console.WriteLine($"    sudo fleet worker install --coordinator http://<host>:{opts.Port} --token {config.RegistrationToken}");
+        Console.WriteLine($"    fleet worker install --coordinator http://<host>:{opts.Port} --token {config.RegistrationToken}");
         Console.WriteLine();
         Console.WriteLine($"  Manage with:");
         Console.WriteLine($"    sudo systemctl status {CoordinatorServiceName}");
@@ -95,6 +109,12 @@ public static class ServiceInstaller
 
     public static async Task UninstallCoordinatorAsync()
     {
+        if (IsWindows)
+        {
+            await WindowsServiceManager.UninstallCoordinatorAsync();
+            return;
+        }
+
         EnsureLinux();
         EnsureRoot();
         await UninstallUnitAsync(CoordinatorServiceName);
@@ -103,6 +123,12 @@ public static class ServiceInstaller
 
     public static async Task CoordinatorStatusAsync()
     {
+        if (IsWindows)
+        {
+            await WindowsServiceManager.CoordinatorStatusAsync();
+            return;
+        }
+
         EnsureLinux();
         await ShowStatusAsync(CoordinatorServiceName);
 
@@ -151,6 +177,12 @@ public static class ServiceInstaller
 
     public static async Task InstallWorkerAsync(WorkerInstallOptions opts)
     {
+        if (IsWindows)
+        {
+            await WindowsServiceManager.InstallWorkerAsync(opts);
+            return;
+        }
+
         EnsureLinux();
         EnsureRoot();
 
@@ -188,6 +220,12 @@ public static class ServiceInstaller
 
     public static async Task UninstallWorkerAsync(string workerName)
     {
+        if (IsWindows)
+        {
+            await WindowsServiceManager.UninstallWorkerAsync(workerName);
+            return;
+        }
+
         EnsureLinux();
         EnsureRoot();
         var serviceName = WorkerServiceName(workerName);
@@ -197,6 +235,12 @@ public static class ServiceInstaller
 
     public static async Task WorkerStatusAsync(string workerName)
     {
+        if (IsWindows)
+        {
+            await WindowsServiceManager.WorkerStatusAsync(workerName);
+            return;
+        }
+
         EnsureLinux();
         await ShowStatusAsync(WorkerServiceName(workerName));
     }
@@ -211,6 +255,12 @@ public static class ServiceInstaller
     /// </summary>
     public static async Task UpdateLocalServicesAsync(UpdateOptions opts)
     {
+        if (IsWindows)
+        {
+            await WindowsServiceManager.UpdateLocalServicesAsync(opts);
+            return;
+        }
+
         EnsureLinux();
         EnsureRoot();
 
@@ -672,31 +722,12 @@ public static class ServiceInstaller
 
     private static string BuildCoordinatorArgs(CoordinatorInstallOptions opts)
     {
-        var parts = new List<string>
-        {
-            $"--port {opts.Port}",
-            $"--data-dir \"{opts.DataDir}\""
-        };
-        if (opts.Token != null) parts.Add($"--token \"{opts.Token}\"");
-        if (opts.JwtSecret != null) parts.Add($"--jwt-secret \"{opts.JwtSecret}\"");
-        if (opts.AdminPassword != null) parts.Add($"--admin-password \"{opts.AdminPassword}\"");
-        if (opts.Urls != null) parts.Add($"--urls \"{opts.Urls}\"");
-        if (opts.NoMdns) parts.Add("--no-mdns");
-        return string.Join(" ", parts);
+        return ServiceCommandLine.BuildCoordinatorArgs(opts);
     }
 
     private static string BuildWorkerArgs(WorkerInstallOptions opts)
     {
-        var parts = new List<string>
-        {
-            $"--coordinator \"{opts.CoordinatorUrl}\"",
-            $"--name \"{opts.Name}\"",
-            $"--data-dir \"{opts.DataDir}\""
-        };
-        if (opts.Token != null) parts.Add($"--token \"{opts.Token}\"");
-        if (opts.PollInterval.HasValue) parts.Add($"--poll-interval {opts.PollInterval}");
-        if (opts.MaxDisk.HasValue) parts.Add($"--max-disk {opts.MaxDisk}");
-        return string.Join(" ", parts);
+        return ServiceCommandLine.BuildWorkerArgs(opts);
     }
 
     // ── Process helpers ──────────────────────────────────────────────────────

--- a/src/DotnetFleet.Tool/SudoElevation.cs
+++ b/src/DotnetFleet.Tool/SudoElevation.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Security.Principal;
+using System.Text;
 
 namespace DotnetFleet.Tool;
 
@@ -15,6 +17,11 @@ public static class SudoElevation
 
     public static bool IsRoot()
     {
+        if (OperatingSystem.IsWindows())
+        {
+            return IsWindowsAdministrator();
+        }
+
         if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
         {
             return true;
@@ -42,17 +49,22 @@ public static class SudoElevation
             return null;
         }
 
-        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
-        {
-            return null;
-        }
-
         var procPath = Environment.ProcessPath;
         var cmdArgs = Environment.GetCommandLineArgs();
         if (string.IsNullOrEmpty(procPath) || cmdArgs.Length == 0)
         {
-            Console.Error.WriteLine("✗ Could not determine current executable path; please re-run with sudo manually.");
+            Console.Error.WriteLine("✗ Could not determine current executable path; please re-run elevated manually.");
             return 1;
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            return ReExecAsWindowsAdministrator(procPath, cmdArgs);
+        }
+
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
+        {
+            return null;
         }
 
         Console.Error.WriteLine("This command requires root. Re-running with sudo (you may be prompted for your password)…");
@@ -122,5 +134,117 @@ public static class SudoElevation
             Console.Error.WriteLine("  Re-run the command manually with sudo.");
             return 1;
         }
+    }
+
+    internal static ProcessStartInfo BuildWindowsElevatedProcess(
+        string processPath,
+        IReadOnlyList<string> commandLineArgs,
+        string workingDirectory)
+    {
+        return new ProcessStartInfo
+        {
+            FileName = processPath,
+            Arguments = string.Join(" ", BuildReExecArguments(processPath, commandLineArgs).Select(QuoteWindowsArgument)),
+            UseShellExecute = true,
+            Verb = "runas",
+            WorkingDirectory = workingDirectory
+        };
+    }
+
+    private static int ReExecAsWindowsAdministrator(string processPath, IReadOnlyList<string> commandLineArgs)
+    {
+        Console.Error.WriteLine("This command requires Administrator privileges. Requesting elevation...");
+        Console.Error.WriteLine();
+
+        try
+        {
+            using var proc = Process.Start(BuildWindowsElevatedProcess(
+                processPath,
+                commandLineArgs,
+                Environment.CurrentDirectory));
+
+            if (proc is null)
+            {
+                Console.Error.WriteLine("✗ Failed to launch elevated process.");
+                return 1;
+            }
+
+            proc.WaitForExit();
+            return proc.ExitCode;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"✗ Could not request elevation: {ex.Message}");
+            Console.Error.WriteLine("  Re-run the command from an Administrator terminal.");
+            return 1;
+        }
+    }
+
+    private static IReadOnlyList<string> BuildReExecArguments(
+        string processPath,
+        IReadOnlyList<string> commandLineArgs)
+    {
+        var procName = Path.GetFileNameWithoutExtension(processPath);
+        var isDotnetHost = string.Equals(procName, "dotnet", StringComparison.OrdinalIgnoreCase);
+        var args = new List<string>();
+
+        if (isDotnetHost && commandLineArgs.Count > 0)
+        {
+            args.Add(commandLineArgs[0]);
+        }
+
+        for (var i = 1; i < commandLineArgs.Count; i++)
+        {
+            args.Add(commandLineArgs[i]);
+        }
+
+        return args;
+    }
+
+    private static string QuoteWindowsArgument(string argument)
+    {
+        if (argument.Length == 0)
+            return "\"\"";
+
+        if (!argument.Any(c => char.IsWhiteSpace(c) || c == '"'))
+            return argument;
+
+        var builder = new StringBuilder();
+        builder.Append('"');
+        var backslashes = 0;
+
+        foreach (var c in argument)
+        {
+            if (c == '\\')
+            {
+                backslashes++;
+                continue;
+            }
+
+            if (c == '"')
+            {
+                builder.Append('\\', backslashes * 2 + 1);
+                builder.Append('"');
+                backslashes = 0;
+                continue;
+            }
+
+            builder.Append('\\', backslashes);
+            backslashes = 0;
+            builder.Append(c);
+        }
+
+        builder.Append('\\', backslashes * 2);
+        builder.Append('"');
+        return builder.ToString();
+    }
+
+    private static bool IsWindowsAdministrator()
+    {
+#pragma warning disable CA1416
+        using var identity = WindowsIdentity.GetCurrent();
+        var principal = new WindowsPrincipal(identity);
+        return principal.IsInRole(WindowsBuiltInRole.Administrator);
+#pragma warning restore CA1416
     }
 }

--- a/src/DotnetFleet.Tool/WindowsServiceManager.cs
+++ b/src/DotnetFleet.Tool/WindowsServiceManager.cs
@@ -454,22 +454,7 @@ internal static class WindowsServiceManager
         if (code != 0)
             return [];
 
-        var services = new List<string>();
-        foreach (var line in stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries))
-        {
-            var trimmed = line.Trim();
-            const string prefix = "SERVICE_NAME:";
-            if (!trimmed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-                continue;
-
-            var serviceName = trimmed[prefix.Length..].Trim();
-            if (string.Equals(serviceName, CoordinatorServiceName, StringComparison.OrdinalIgnoreCase) ||
-                serviceName.StartsWith("fleet-worker-", StringComparison.OrdinalIgnoreCase))
-                services.Add(serviceName);
-        }
-
-        services.Sort(StringComparer.OrdinalIgnoreCase);
-        return services;
+        return FindFleetServiceNames(stdout).ToList();
     }
 
     private static string? ReadServiceImagePath(string serviceName)
@@ -482,17 +467,7 @@ internal static class WindowsServiceManager
             if (code != 0)
                 return null;
 
-            foreach (var line in stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries))
-            {
-                var trimmed = line.Trim();
-                const string prefix = "BINARY_PATH_NAME";
-                if (!trimmed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-                    continue;
-
-                var colon = trimmed.IndexOf(':');
-                if (colon >= 0 && colon + 1 < trimmed.Length)
-                    return trimmed[(colon + 1)..].Trim();
-            }
+            return FindServiceImagePath(stdout);
         }
         catch
         {
@@ -500,6 +475,46 @@ internal static class WindowsServiceManager
         }
 
         return null;
+    }
+
+    internal static IReadOnlyList<string> FindFleetServiceNames(string scQueryOutput)
+    {
+        var services = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var line in scQueryOutput.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var value = ReadScLineValue(line);
+            if (value is null)
+                continue;
+
+            if (string.Equals(value, CoordinatorServiceName, StringComparison.OrdinalIgnoreCase) ||
+                value.StartsWith("fleet-worker-", StringComparison.OrdinalIgnoreCase))
+                services.Add(value);
+        }
+
+        return services.Order(StringComparer.OrdinalIgnoreCase).ToArray();
+    }
+
+    internal static string? FindServiceImagePath(string scQueryConfigOutput)
+    {
+        foreach (var line in scQueryConfigOutput.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var value = ReadScLineValue(line);
+            if (value?.Contains(".exe", StringComparison.OrdinalIgnoreCase) == true)
+                return value;
+        }
+
+        return null;
+    }
+
+    private static string? ReadScLineValue(string line)
+    {
+        var colon = line.IndexOf(':');
+        if (colon < 0 || colon + 1 >= line.Length)
+            return null;
+
+        var value = line[(colon + 1)..].Trim();
+        return string.IsNullOrEmpty(value) ? null : value;
     }
 
     private static async Task<(string stdout, string stderr, int exitCode)> RunScAsync(

--- a/src/DotnetFleet.Tool/WindowsServiceManager.cs
+++ b/src/DotnetFleet.Tool/WindowsServiceManager.cs
@@ -1,0 +1,580 @@
+using System.Diagnostics;
+using System.Security.Principal;
+
+namespace DotnetFleet.Tool;
+
+internal static class WindowsServiceManager
+{
+    private const string RootFolderName = "DotnetFleet";
+    private const string CoordinatorServiceName = "fleet-coordinator";
+
+    public static string WorkerServiceName(string workerName) => $"fleet-worker-{workerName}";
+
+    public static string GetDefaultWindowsDataDir(string component, string? programDataRoot = null)
+    {
+        var root = programDataRoot;
+        if (string.IsNullOrWhiteSpace(root))
+        {
+            root = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+        }
+
+        if (string.IsNullOrWhiteSpace(root))
+        {
+            root = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                "ProgramData");
+        }
+
+        if (root.Contains('\\') && !root.Contains('/'))
+            return string.Join('\\', root.TrimEnd('\\'), RootFolderName, component);
+
+        return Path.Combine(root, RootFolderName, component);
+    }
+
+    public static string BuildCoordinatorImagePath(string fleetPath, ServiceInstaller.CoordinatorInstallOptions opts)
+    {
+        return $"{ServiceCommandLine.QuoteArgument(fleetPath)} coordinator {ServiceCommandLine.BuildCoordinatorArgs(opts)}";
+    }
+
+    public static string BuildWorkerImagePath(string fleetPath, ServiceInstaller.WorkerInstallOptions opts)
+    {
+        return $"{ServiceCommandLine.QuoteArgument(fleetPath)} worker {ServiceCommandLine.BuildWorkerArgs(opts)}";
+    }
+
+    public static LocalCoordinatorDiscovery.Result? TryDiscoverCoordinatorFromInstalledService()
+    {
+        if (!OperatingSystem.IsWindows())
+            return null;
+
+        var imagePath = ReadServiceImagePath(CoordinatorServiceName);
+        return imagePath is null ? null : TryDiscoverCoordinatorFromImagePath(imagePath);
+    }
+
+    public static LocalCoordinatorDiscovery.Result? TryDiscoverCoordinatorFromImagePath(string imagePath)
+    {
+        var args = ServiceCommandLine.Split(imagePath);
+        var dataDir = ServiceCommandLine.GetOptionValue(args, "--data-dir");
+        if (string.IsNullOrWhiteSpace(dataDir))
+            return null;
+
+        return LocalCoordinatorDiscovery.TryLoadFromDataDir(dataDir, "Windows service ImagePath");
+    }
+
+    public static async Task InstallCoordinatorAsync(ServiceInstaller.CoordinatorInstallOptions opts)
+    {
+        EnsureWindows();
+        EnsureAdministrator();
+
+        Directory.CreateDirectory(opts.DataDir);
+        var config = FleetConfig.LoadOrCreateCoordinatorConfig(
+            opts.DataDir, opts.JwtSecret, opts.Token, opts.Port);
+
+        var fleetPath = await EnsureFleetServiceToolAsync();
+        var imagePath = BuildCoordinatorImagePath(fleetPath, opts);
+        await InstallServiceAsync(
+            CoordinatorServiceName,
+            "DotnetFleet Coordinator",
+            "DotnetFleet Coordinator",
+            imagePath);
+
+        Console.WriteLine();
+        Console.WriteLine($"  ✓ Coordinator installed as Windows service '{CoordinatorServiceName}'");
+        Console.WriteLine($"    Listening on port {opts.Port}");
+        Console.WriteLine($"    Registration token: {config.RegistrationToken}");
+        Console.WriteLine($"    Data directory: {opts.DataDir}");
+        Console.WriteLine();
+        Console.WriteLine("  Connect workers with:");
+        Console.WriteLine($"    fleet worker install --coordinator http://<host>:{opts.Port} --token {config.RegistrationToken}");
+        Console.WriteLine();
+        Console.WriteLine("  Manage with:");
+        Console.WriteLine($"    Get-Service {CoordinatorServiceName}");
+        Console.WriteLine($"    Stop-Service {CoordinatorServiceName}");
+        Console.WriteLine("    fleet coordinator uninstall");
+        Console.WriteLine();
+    }
+
+    public static async Task UninstallCoordinatorAsync()
+    {
+        EnsureWindows();
+        EnsureAdministrator();
+        await UninstallServiceAsync(CoordinatorServiceName);
+        Console.WriteLine($"  ✓ Coordinator service '{CoordinatorServiceName}' removed.");
+    }
+
+    public static async Task CoordinatorStatusAsync()
+    {
+        EnsureWindows();
+        await ShowStatusAsync(CoordinatorServiceName);
+
+        var discovered = TryDiscoverCoordinatorFromInstalledService();
+        if (discovered != null)
+        {
+            Console.WriteLine($"  Token: {discovered.Token}");
+            Console.WriteLine($"  URL:   {discovered.Url}");
+            Console.WriteLine();
+        }
+    }
+
+    public static async Task InstallWorkerAsync(ServiceInstaller.WorkerInstallOptions opts)
+    {
+        EnsureWindows();
+        EnsureAdministrator();
+
+        Directory.CreateDirectory(opts.DataDir);
+        var fleetPath = await EnsureFleetServiceToolAsync();
+        var serviceName = WorkerServiceName(opts.Name);
+        var imagePath = BuildWorkerImagePath(fleetPath, opts);
+
+        await InstallServiceAsync(
+            serviceName,
+            $"DotnetFleet Worker ({opts.Name})",
+            $"DotnetFleet Worker ({opts.Name})",
+            imagePath);
+
+        Console.WriteLine();
+        Console.WriteLine($"  ✓ Worker '{opts.Name}' installed as Windows service '{serviceName}'");
+        Console.WriteLine($"    Coordinator: {opts.CoordinatorUrl}");
+        Console.WriteLine($"    Data directory: {opts.DataDir}");
+        Console.WriteLine();
+        Console.WriteLine("  Manage with:");
+        Console.WriteLine($"    Get-Service {serviceName}");
+        Console.WriteLine($"    Stop-Service {serviceName}");
+        Console.WriteLine($"    fleet worker uninstall --name {opts.Name}");
+        Console.WriteLine();
+    }
+
+    public static async Task UninstallWorkerAsync(string workerName)
+    {
+        EnsureWindows();
+        EnsureAdministrator();
+        var serviceName = WorkerServiceName(workerName);
+        await UninstallServiceAsync(serviceName);
+        Console.WriteLine($"  ✓ Worker service '{serviceName}' removed.");
+    }
+
+    public static async Task WorkerStatusAsync(string workerName)
+    {
+        EnsureWindows();
+        await ShowStatusAsync(WorkerServiceName(workerName));
+    }
+
+    public static async Task UpdateLocalServicesAsync(ServiceInstaller.UpdateOptions opts)
+    {
+        EnsureWindows();
+        EnsureAdministrator();
+
+        var installedServices = await DiscoverInstalledFleetServicesAsync();
+
+        Console.WriteLine();
+        Console.WriteLine("  Updating DotnetFleet on this machine");
+        Console.WriteLine("  ────────────────────────────────────");
+        if (installedServices.Count == 0)
+        {
+            Console.WriteLine("  (no local fleet services found)");
+        }
+        else
+        {
+            foreach (var svc in installedServices)
+                Console.WriteLine($"    • {svc}");
+        }
+        Console.WriteLine();
+
+        var servicesStoppedForUpdate = false;
+        if (!opts.SkipToolUpdate && installedServices.Count > 0)
+        {
+            Console.WriteLine("  Stopping services before updating the service tool...");
+            foreach (var serviceName in installedServices)
+                await StopServiceAsync(serviceName);
+            servicesStoppedForUpdate = true;
+            Console.WriteLine();
+        }
+
+        if (!opts.SkipToolUpdate)
+        {
+            var versionBefore = await GetInstalledServiceToolVersionAsync();
+            var verb = File.Exists(Path.Combine(GetServiceToolsDir(), "fleet.exe")) ? "update" : "install";
+            var exitCode = await RunDotnetToolPathCommandAsync(verb, opts.Version, opts.IncludePrerelease);
+            if (exitCode != 0)
+            {
+                Console.Error.WriteLine();
+                Console.Error.WriteLine($"  ✗ 'dotnet tool {verb}' failed. Services were not restarted.");
+                Console.Error.WriteLine("    Re-run with --skip-tool-update to only restart services.");
+                if (servicesStoppedForUpdate)
+                    await StartServicesBestEffortAsync(installedServices);
+                throw new InvalidOperationException($"dotnet tool {verb} failed.");
+            }
+
+            var versionAfter = await GetInstalledServiceToolVersionAsync();
+            Console.WriteLine();
+            if (versionBefore == null && versionAfter != null)
+                Console.WriteLine($"  ✓ DotnetFleet.Tool installed: {versionAfter}");
+            else if (versionBefore != null && versionAfter != null &&
+                !string.Equals(versionBefore, versionAfter, StringComparison.Ordinal))
+                Console.WriteLine($"  ✓ DotnetFleet.Tool updated: {versionBefore} → {versionAfter}");
+            else if (versionAfter != null)
+                Console.WriteLine($"  • DotnetFleet.Tool already up to date ({versionAfter}); nothing to update.");
+            else
+                Console.WriteLine("  • DotnetFleet.Tool: could not determine installed version.");
+        }
+        else
+        {
+            Console.WriteLine("  • Skipping 'dotnet tool update' (--skip-tool-update)");
+        }
+
+        if (installedServices.Count == 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("  ✓ Tool updated. No services to restart.");
+            Console.WriteLine();
+            return;
+        }
+
+        Console.WriteLine();
+        Console.WriteLine(servicesStoppedForUpdate ? "  Starting services..." : "  Restarting services...");
+
+        var failures = new List<string>();
+        foreach (var serviceName in installedServices)
+        {
+            var ok = servicesStoppedForUpdate
+                ? await StartServiceAsync(serviceName)
+                : await RestartServiceAsync(serviceName);
+            if (ok)
+            {
+                Console.WriteLine($"    ✓ {serviceName}");
+                continue;
+            }
+
+            failures.Add(serviceName);
+            Console.Error.WriteLine($"    ✗ {serviceName}");
+        }
+
+        Console.WriteLine();
+        if (failures.Count == 0)
+        {
+            Console.WriteLine("  ✓ All fleet services updated and restarted.");
+            Console.WriteLine();
+            return;
+        }
+
+        Console.Error.WriteLine($"  ⚠ {failures.Count} service(s) failed to restart cleanly:");
+        foreach (var svc in failures)
+            Console.Error.WriteLine($"      sc.exe query {svc}");
+        throw new InvalidOperationException("Some services failed to restart.");
+    }
+
+    private static string GetServiceToolsDir()
+    {
+        return GetDefaultWindowsDataDir("tools");
+    }
+
+    private static async Task<string> EnsureFleetServiceToolAsync()
+    {
+        var toolsDir = GetServiceToolsDir();
+        Directory.CreateDirectory(toolsDir);
+
+        var fleetPath = Path.Combine(toolsDir, "fleet.exe");
+        if (File.Exists(fleetPath))
+            return fleetPath;
+
+        Console.WriteLine();
+        Console.WriteLine("  • DotnetFleet.Tool service-local tool is required for Windows services.");
+        Console.WriteLine($"    Installing into {toolsDir}...");
+        Console.WriteLine();
+
+        var pinnedVersion = ExtractToolVersionFromPath(Environment.ProcessPath);
+        var exitCode = await RunDotnetToolPathCommandAsync("install", pinnedVersion, includePrerelease: false);
+        if (exitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Failed to install DotnetFleet.Tool into '{toolsDir}' " +
+                $"(dotnet tool install exited with code {exitCode}).");
+        }
+
+        if (!File.Exists(fleetPath))
+        {
+            throw new InvalidOperationException(
+                $"Tool installation succeeded but '{fleetPath}' was not found.");
+        }
+
+        Console.WriteLine($"  ✓ Service tool installed at {fleetPath}");
+        Console.WriteLine();
+        return fleetPath;
+    }
+
+    private static async Task<int> RunDotnetToolPathCommandAsync(
+        string verb,
+        string? version,
+        bool includePrerelease)
+    {
+        var toolsDir = GetServiceToolsDir();
+        Directory.CreateDirectory(toolsDir);
+
+        var args = new List<string> { "tool", verb, "--tool-path", toolsDir, "DotnetFleet.Tool" };
+        if (!string.IsNullOrWhiteSpace(version))
+        {
+            args.Add("--version");
+            args.Add(version);
+        }
+        if (includePrerelease)
+            args.Add("--prerelease");
+
+        var (stdout, stderr, code) = await RunProcessAsync("dotnet", args, throwOnError: false);
+        if (!string.IsNullOrWhiteSpace(stdout))
+            Console.Write(stdout);
+        if (!string.IsNullOrWhiteSpace(stderr))
+            Console.Error.Write(stderr);
+        return code;
+    }
+
+    private static async Task<string?> GetInstalledServiceToolVersionAsync()
+    {
+        var toolsDir = GetServiceToolsDir();
+        var (stdout, _, code) = await RunProcessAsync(
+            "dotnet",
+            ["tool", "list", "--tool-path", toolsDir],
+            throwOnError: false);
+        if (code != 0)
+            return null;
+
+        foreach (var line in stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var parts = line.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length >= 2 &&
+                string.Equals(parts[0], "dotnetfleet.tool", StringComparison.OrdinalIgnoreCase))
+                return parts[1];
+        }
+
+        return null;
+    }
+
+    private static async Task InstallServiceAsync(
+        string serviceName,
+        string displayName,
+        string description,
+        string imagePath)
+    {
+        if (await ServiceExistsAsync(serviceName))
+        {
+            await StopServiceAsync(serviceName);
+            await RunScAsync(["delete", serviceName], throwOnError: false);
+            await Task.Delay(1000);
+        }
+
+        await RunScAsync([
+            "create", serviceName,
+            "binPath=", imagePath,
+            "start=", "auto",
+            "DisplayName=", displayName
+        ]);
+
+        await RunScAsync(["description", serviceName, description], throwOnError: false);
+        await RunScAsync([
+            "failure", serviceName,
+            "reset=", "60",
+            "actions=", "restart/5000/restart/5000/restart/5000"
+        ], throwOnError: false);
+        await RunScAsync(["start", serviceName], throwOnError: false);
+
+        await Task.Delay(1500);
+        if (!await IsServiceRunningAsync(serviceName))
+            Console.Error.WriteLine($"  ⚠ Service started but may not be running yet. Check: sc.exe query {serviceName}");
+    }
+
+    private static async Task UninstallServiceAsync(string serviceName)
+    {
+        if (!await ServiceExistsAsync(serviceName))
+        {
+            Console.Error.WriteLine($"  Service '{serviceName}' is not installed.");
+            return;
+        }
+
+        await StopServiceAsync(serviceName);
+        await RunScAsync(["delete", serviceName], throwOnError: false);
+    }
+
+    private static async Task ShowStatusAsync(string serviceName)
+    {
+        if (!await ServiceExistsAsync(serviceName))
+        {
+            Console.WriteLine($"  Service '{serviceName}' is not installed.");
+            return;
+        }
+
+        var (stdout, _, _) = await RunScAsync(["query", serviceName], throwOnError: false);
+        Console.WriteLine();
+        Console.WriteLine(stdout.TrimEnd());
+        Console.WriteLine();
+        Console.WriteLine($"  Logs: use Event Viewer or the logs directory under {RootFolderName} data dir.");
+        Console.WriteLine();
+    }
+
+    private static async Task<bool> ServiceExistsAsync(string serviceName)
+    {
+        var (_, _, code) = await RunScAsync(["query", serviceName], throwOnError: false);
+        return code == 0;
+    }
+
+    private static async Task<bool> IsServiceRunningAsync(string serviceName)
+    {
+        var (stdout, _, code) = await RunScAsync(["query", serviceName], throwOnError: false);
+        return code == 0 && stdout.Contains("RUNNING", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static async Task StopServiceAsync(string serviceName)
+    {
+        await RunScAsync(["stop", serviceName], throwOnError: false);
+        await Task.Delay(1000);
+    }
+
+    private static async Task<bool> RestartServiceAsync(string serviceName)
+    {
+        await StopServiceAsync(serviceName);
+        return await StartServiceAsync(serviceName);
+    }
+
+    private static async Task<bool> StartServiceAsync(string serviceName)
+    {
+        await RunScAsync(["start", serviceName], throwOnError: false);
+        await Task.Delay(1500);
+        return await IsServiceRunningAsync(serviceName);
+    }
+
+    private static async Task StartServicesBestEffortAsync(IReadOnlyList<string> serviceNames)
+    {
+        foreach (var serviceName in serviceNames)
+        {
+            try { await StartServiceAsync(serviceName); }
+            catch { /* best effort after failed update */ }
+        }
+    }
+
+    private static async Task<List<string>> DiscoverInstalledFleetServicesAsync()
+    {
+        var (stdout, _, code) = await RunScAsync(["query", "state=", "all"], throwOnError: false);
+        if (code != 0)
+            return [];
+
+        var services = new List<string>();
+        foreach (var line in stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var trimmed = line.Trim();
+            const string prefix = "SERVICE_NAME:";
+            if (!trimmed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var serviceName = trimmed[prefix.Length..].Trim();
+            if (string.Equals(serviceName, CoordinatorServiceName, StringComparison.OrdinalIgnoreCase) ||
+                serviceName.StartsWith("fleet-worker-", StringComparison.OrdinalIgnoreCase))
+                services.Add(serviceName);
+        }
+
+        services.Sort(StringComparer.OrdinalIgnoreCase);
+        return services;
+    }
+
+    private static string? ReadServiceImagePath(string serviceName)
+    {
+        try
+        {
+            var (stdout, _, code) = RunScAsync(["qc", serviceName], throwOnError: false)
+                .GetAwaiter()
+                .GetResult();
+            if (code != 0)
+                return null;
+
+            foreach (var line in stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var trimmed = line.Trim();
+                const string prefix = "BINARY_PATH_NAME";
+                if (!trimmed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var colon = trimmed.IndexOf(':');
+                if (colon >= 0 && colon + 1 < trimmed.Length)
+                    return trimmed[(colon + 1)..].Trim();
+            }
+        }
+        catch
+        {
+            // Best-effort discovery.
+        }
+
+        return null;
+    }
+
+    private static async Task<(string stdout, string stderr, int exitCode)> RunScAsync(
+        IReadOnlyList<string> args,
+        bool throwOnError = true)
+    {
+        return await RunProcessAsync("sc.exe", args, throwOnError);
+    }
+
+    private static async Task<(string stdout, string stderr, int exitCode)> RunProcessAsync(
+        string fileName,
+        IReadOnlyList<string> args,
+        bool throwOnError = true)
+    {
+        var psi = new ProcessStartInfo(fileName)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        foreach (var arg in args)
+            psi.ArgumentList.Add(arg);
+
+        using var proc = Process.Start(psi)!;
+        var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+        var stderrTask = proc.StandardError.ReadToEndAsync();
+        await proc.WaitForExitAsync();
+        var stdout = await stdoutTask;
+        var stderr = await stderrTask;
+
+        if (throwOnError && proc.ExitCode != 0)
+            throw new InvalidOperationException(
+                $"{fileName} {string.Join(" ", args)} failed (exit {proc.ExitCode}): {stderr}");
+
+        return (stdout, stderr, proc.ExitCode);
+    }
+
+    private static void EnsureWindows()
+    {
+        if (!OperatingSystem.IsWindows())
+            throw new PlatformNotSupportedException("Windows service management is only supported on Windows.");
+    }
+
+    private static void EnsureAdministrator()
+    {
+#pragma warning disable CA1416 // Guarded by EnsureWindows before every call site.
+        using var identity = WindowsIdentity.GetCurrent();
+        var principal = new WindowsPrincipal(identity);
+        if (principal.IsInRole(WindowsBuiltInRole.Administrator))
+            return;
+#pragma warning restore CA1416
+
+        Console.Error.WriteLine("Error: This command requires an elevated Administrator terminal.");
+        throw new UnauthorizedAccessException("Administrator privileges required to manage Windows services.");
+    }
+
+    private static string? ExtractToolVersionFromPath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return null;
+
+        var normalized = path.Replace('\\', '/');
+        const string marker = "/dotnetfleet.tool/";
+        var idx = normalized.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (idx < 0)
+            return null;
+
+        var rest = normalized[(idx + marker.Length)..];
+        var slash = rest.IndexOf('/');
+        if (slash <= 0)
+            return null;
+
+        var candidate = rest[..slash];
+        return candidate.Length > 0 && char.IsDigit(candidate[0]) ? candidate : null;
+    }
+}

--- a/src/DotnetFleet.Worker/DotnetFleet.Worker.csproj
+++ b/src/DotnetFleet.Worker/DotnetFleet.Worker.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="CSharpFunctionalExtensions" />
     <PackageReference Include="Serilog" />
@@ -18,6 +19,9 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DotnetFleet.Core\DotnetFleet.Core.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="DotnetFleet.Tests" />
   </ItemGroup>
   <ItemGroup>
     <None Update="appsettings.json" CopyToOutputDirectory="PreserveNewest" />

--- a/src/DotnetFleet.Worker/WorkerHostBuilder.cs
+++ b/src/DotnetFleet.Worker/WorkerHostBuilder.cs
@@ -30,16 +30,26 @@ public static class WorkerHostBuilder
 
         var builder = Host.CreateApplicationBuilder(args);
 
+        builder.Services.AddWindowsService(serviceOptions =>
+        {
+            serviceOptions.ServiceName = "DotnetFleet Worker";
+        });
+
         builder.Configuration.AddEnvironmentVariables(prefix: "FLEET_");
 
         // Apply CLI overrides
         ApplyOverrides(builder.Configuration, options);
 
+        var logPath = ResolveLogPath(options.DataDir);
+        var logDir = Path.GetDirectoryName(logPath);
+        if (!string.IsNullOrEmpty(logDir))
+            Directory.CreateDirectory(logDir);
+
         Log.Logger = new LoggerConfiguration()
             .ReadFrom.Configuration(builder.Configuration)
             .Enrich.FromLogContext()
             .WriteTo.Console()
-            .WriteTo.File("logs/worker-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 14)
+            .WriteTo.File(logPath, rollingInterval: RollingInterval.Day, retainedFileCountLimit: 14)
             .CreateLogger();
 
         builder.Logging.ClearProviders();
@@ -144,5 +154,12 @@ public static class WorkerHostBuilder
 
         if (overrides.Count > 0)
             config.AddInMemoryCollection(overrides);
+    }
+
+    internal static string ResolveLogPath(string? dataDir)
+    {
+        return string.IsNullOrEmpty(dataDir)
+            ? Path.Combine("logs", "worker-.log")
+            : Path.Combine(dataDir, "logs", "worker-.log");
     }
 }

--- a/src/DotnetFleet/ViewModels/JobPhaseRow.cs
+++ b/src/DotnetFleet/ViewModels/JobPhaseRow.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Globalization;
 using DotnetFleet.Core.Domain;
 using ReactiveUI;
 using Zafiro.UI;
@@ -70,7 +71,7 @@ public sealed class JobPhaseRow : ReactiveObject
         DurationText = phase.DurationMs switch
         {
             { } ms when ms < 1000 => $"{ms} ms",
-            { } ms => $"{ms / 1000.0:0.0}s",
+            { } ms => $"{(ms / 1000.0).ToString("0.0", CultureInfo.InvariantCulture)}s",
             null when phase.EndedAt is null => "running…",
             _ => ""
         };

--- a/tests/DotnetFleet.Tests/LocalCoordinatorDiscoveryTests.cs
+++ b/tests/DotnetFleet.Tests/LocalCoordinatorDiscoveryTests.cs
@@ -30,6 +30,7 @@ public class LocalCoordinatorDiscoveryTests : IDisposable
 
         var prevHome = Environment.GetEnvironmentVariable("HOME");
         var prevUserProfile = Environment.GetEnvironmentVariable("USERPROFILE");
+        var prevSudoUser = Environment.GetEnvironmentVariable("SUDO_USER");
         Environment.SetEnvironmentVariable("HOME", fakeHome);
         Environment.SetEnvironmentVariable("USERPROFILE", fakeHome);
         Environment.SetEnvironmentVariable("SUDO_USER", null);
@@ -47,6 +48,7 @@ public class LocalCoordinatorDiscoveryTests : IDisposable
         {
             Environment.SetEnvironmentVariable("HOME", prevHome);
             Environment.SetEnvironmentVariable("USERPROFILE", prevUserProfile);
+            Environment.SetEnvironmentVariable("SUDO_USER", prevSudoUser);
         }
     }
 
@@ -57,6 +59,8 @@ public class LocalCoordinatorDiscoveryTests : IDisposable
         Directory.CreateDirectory(fakeHome);
 
         var prevHome = Environment.GetEnvironmentVariable("HOME");
+        var prevUserProfile = Environment.GetEnvironmentVariable("USERPROFILE");
+        var prevSudoUser = Environment.GetEnvironmentVariable("SUDO_USER");
         Environment.SetEnvironmentVariable("HOME", fakeHome);
         Environment.SetEnvironmentVariable("USERPROFILE", fakeHome);
         Environment.SetEnvironmentVariable("SUDO_USER", null);
@@ -69,6 +73,8 @@ public class LocalCoordinatorDiscoveryTests : IDisposable
         finally
         {
             Environment.SetEnvironmentVariable("HOME", prevHome);
+            Environment.SetEnvironmentVariable("USERPROFILE", prevUserProfile);
+            Environment.SetEnvironmentVariable("SUDO_USER", prevSudoUser);
         }
     }
 
@@ -82,6 +88,8 @@ public class LocalCoordinatorDiscoveryTests : IDisposable
             "{ \"jwtSecret\": \"x\", \"port\": 5000 }");
 
         var prevHome = Environment.GetEnvironmentVariable("HOME");
+        var prevUserProfile = Environment.GetEnvironmentVariable("USERPROFILE");
+        var prevSudoUser = Environment.GetEnvironmentVariable("SUDO_USER");
         Environment.SetEnvironmentVariable("HOME", fakeHome);
         Environment.SetEnvironmentVariable("USERPROFILE", fakeHome);
         Environment.SetEnvironmentVariable("SUDO_USER", null);
@@ -94,6 +102,8 @@ public class LocalCoordinatorDiscoveryTests : IDisposable
         finally
         {
             Environment.SetEnvironmentVariable("HOME", prevHome);
+            Environment.SetEnvironmentVariable("USERPROFILE", prevUserProfile);
+            Environment.SetEnvironmentVariable("SUDO_USER", prevSudoUser);
         }
     }
 
@@ -106,6 +116,8 @@ public class LocalCoordinatorDiscoveryTests : IDisposable
         File.WriteAllText(Path.Combine(coordDir, "config.json"), "not-json{");
 
         var prevHome = Environment.GetEnvironmentVariable("HOME");
+        var prevUserProfile = Environment.GetEnvironmentVariable("USERPROFILE");
+        var prevSudoUser = Environment.GetEnvironmentVariable("SUDO_USER");
         Environment.SetEnvironmentVariable("HOME", fakeHome);
         Environment.SetEnvironmentVariable("USERPROFILE", fakeHome);
         Environment.SetEnvironmentVariable("SUDO_USER", null);
@@ -118,6 +130,8 @@ public class LocalCoordinatorDiscoveryTests : IDisposable
         finally
         {
             Environment.SetEnvironmentVariable("HOME", prevHome);
+            Environment.SetEnvironmentVariable("USERPROFILE", prevUserProfile);
+            Environment.SetEnvironmentVariable("SUDO_USER", prevSudoUser);
         }
     }
 

--- a/tests/DotnetFleet.Tests/ServiceLogPathTests.cs
+++ b/tests/DotnetFleet.Tests/ServiceLogPathTests.cs
@@ -1,0 +1,23 @@
+using DotnetFleet.Coordinator;
+using DotnetFleet.WorkerService;
+
+namespace DotnetFleet.Tests;
+
+public class ServiceLogPathTests
+{
+    [Fact]
+    public void CoordinatorLogPath_UsesDataDirWhenProvided()
+    {
+        var path = CoordinatorHostBuilder.ResolveLogPath(@"C:\ProgramData\DotnetFleet\coordinator");
+
+        path.Should().Be(Path.Combine(@"C:\ProgramData\DotnetFleet\coordinator", "logs", "coordinator-.log"));
+    }
+
+    [Fact]
+    public void WorkerLogPath_UsesDataDirWhenProvided()
+    {
+        var path = WorkerHostBuilder.ResolveLogPath(@"C:\ProgramData\DotnetFleet\worker-build-01");
+
+        path.Should().Be(Path.Combine(@"C:\ProgramData\DotnetFleet\worker-build-01", "logs", "worker-.log"));
+    }
+}

--- a/tests/DotnetFleet.Tests/SudoElevationTests.cs
+++ b/tests/DotnetFleet.Tests/SudoElevationTests.cs
@@ -1,0 +1,46 @@
+using DotnetFleet.Tool;
+
+namespace DotnetFleet.Tests;
+
+public class SudoElevationTests
+{
+    [Fact]
+    public void BuildWindowsElevatedProcess_WhenRunningUnderDotnet_ShouldPassDllAndUserArguments()
+    {
+        var process = SudoElevation.BuildWindowsElevatedProcess(
+            @"C:\Program Files\dotnet\dotnet.exe",
+            [
+                @"C:\Tools With Space\DotnetFleet.Tool.dll",
+                "coordinator",
+                "install",
+                "--data-dir",
+                @"C:\ProgramData\DotnetFleet\coordinator data"
+            ],
+            @"C:\Users\JMN\Repos\DotnetFleet");
+
+        process.FileName.Should().Be(@"C:\Program Files\dotnet\dotnet.exe");
+        process.Verb.Should().Be("runas");
+        process.UseShellExecute.Should().BeTrue();
+        process.WorkingDirectory.Should().Be(@"C:\Users\JMN\Repos\DotnetFleet");
+        process.Arguments.Should().Be(
+            "\"C:\\Tools With Space\\DotnetFleet.Tool.dll\" coordinator install --data-dir \"C:\\ProgramData\\DotnetFleet\\coordinator data\"");
+    }
+
+    [Fact]
+    public void BuildWindowsElevatedProcess_WhenRunningAsAppHost_ShouldPassOnlyUserArguments()
+    {
+        var process = SudoElevation.BuildWindowsElevatedProcess(
+            @"C:\ProgramData\DotnetFleet\tools\fleet.exe",
+            [
+                @"C:\ProgramData\DotnetFleet\tools\DotnetFleet.Tool.dll",
+                "worker",
+                "install",
+                "--name",
+                "build worker"
+            ],
+            @"C:\Users\JMN\Repos\DotnetFleet");
+
+        process.FileName.Should().Be(@"C:\ProgramData\DotnetFleet\tools\fleet.exe");
+        process.Arguments.Should().Be("worker install --name \"build worker\"");
+    }
+}

--- a/tests/DotnetFleet.Tests/WindowsServiceManagerTests.cs
+++ b/tests/DotnetFleet.Tests/WindowsServiceManagerTests.cs
@@ -76,6 +76,41 @@ public class WindowsServiceManagerTests : IDisposable
         dataDir.Should().Be(@"C:\ProgramData\DotnetFleet\worker-build-01");
     }
 
+    [Fact]
+    public void FindFleetServiceNames_ParsesLocalizedScQueryOutput()
+    {
+        const string output = """
+            NOMBRE_DE_SERVICIO: Appinfo
+            NOMBRE_PARA_MOSTRAR: Información de la aplicación
+
+            NOMBRE_SERVICIO: fleet-coordinator
+            NOMBRE_MOSTRAR : DotnetFleet Coordinator
+
+            NOMBRE_DE_SERVICIO: fleet-worker-smoke-worker
+            NOMBRE_PARA_MOSTRAR: DotnetFleet Worker (smoke-worker)
+            """;
+
+        var services = WindowsServiceManager.FindFleetServiceNames(output);
+
+        services.Should().Equal("fleet-coordinator", "fleet-worker-smoke-worker");
+    }
+
+    [Fact]
+    public void FindServiceImagePath_ParsesLocalizedScQueryConfigOutput()
+    {
+        const string output = """
+            NOMBRE_SERVICIO: fleet-coordinator
+                    TIPO               : 10  WIN32_OWN_PROCESS
+                    TIPO_INICIO        : 2   AUTO_START
+                    NOMBRE_RUTA_BINARIO: "C:\ProgramData\DotnetFleet\tools\fleet.exe" coordinator --port 57130 --data-dir "C:\ProgramData\DotnetFleet\coordinator"
+                    NOMBRE_INICIO_SERVICIO: LocalSystem
+            """;
+
+        var imagePath = WindowsServiceManager.FindServiceImagePath(output);
+
+        imagePath.Should().Be("\"C:\\ProgramData\\DotnetFleet\\tools\\fleet.exe\" coordinator --port 57130 --data-dir \"C:\\ProgramData\\DotnetFleet\\coordinator\"");
+    }
+
     private static void WriteConfig(string path, string token, int port)
     {
         var obj = new

--- a/tests/DotnetFleet.Tests/WindowsServiceManagerTests.cs
+++ b/tests/DotnetFleet.Tests/WindowsServiceManagerTests.cs
@@ -1,0 +1,89 @@
+using System.Text.Json;
+using DotnetFleet.Tool;
+
+namespace DotnetFleet.Tests;
+
+public class WindowsServiceManagerTests : IDisposable
+{
+    private readonly string tempRoot;
+
+    public WindowsServiceManagerTests()
+    {
+        tempRoot = Path.Combine(Path.GetTempPath(), "fleet-windows-service-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(tempRoot, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void BuildCoordinatorImagePath_QuotesExecutableAndArguments()
+    {
+        var opts = new ServiceInstaller.CoordinatorInstallOptions(
+            Port: 6123,
+            DataDir: @"C:\ProgramData\DotnetFleet\coordinator data",
+            Token: "token with spaces",
+            JwtSecret: null,
+            AdminPassword: "admin pass",
+            Urls: "http://0.0.0.0:6123",
+            NoMdns: true);
+
+        var imagePath = WindowsServiceManager.BuildCoordinatorImagePath(
+            @"C:\Program Files\DotnetFleet\tools\fleet.exe",
+            opts);
+
+        imagePath.Should().Be(
+            "\"C:\\Program Files\\DotnetFleet\\tools\\fleet.exe\" coordinator --port 6123 --data-dir \"C:\\ProgramData\\DotnetFleet\\coordinator data\" --token \"token with spaces\" --admin-password \"admin pass\" --urls \"http://0.0.0.0:6123\" --no-mdns");
+    }
+
+    [Fact]
+    public void TryDiscoverCoordinatorFromImagePath_LoadsTokenAndPortFromQuotedDataDir()
+    {
+        var dataDir = Path.Combine(tempRoot, "coordinator data");
+        Directory.CreateDirectory(dataDir);
+        WriteConfig(Path.Combine(dataDir, "config.json"), token: "token-abc", port: 7654);
+
+        var imagePath =
+            $"\"C:\\ProgramData\\DotnetFleet\\tools\\fleet.exe\" coordinator --port 5000 --data-dir \"{dataDir}\"";
+
+        var result = WindowsServiceManager.TryDiscoverCoordinatorFromImagePath(imagePath);
+
+        result.Should().NotBeNull();
+        result!.Url.Should().Be("http://localhost:7654");
+        result.Token.Should().Be("token-abc");
+        result.Source.Should().Contain("Windows service ImagePath");
+    }
+
+    [Fact]
+    public void Split_PreservesBackslashesInQuotedWindowsPaths()
+    {
+        var args = ServiceCommandLine.Split(
+            "\"C:\\ProgramData\\DotnetFleet\\tools\\fleet.exe\" coordinator --data-dir \"C:\\ProgramData\\DotnetFleet\\coordinator\"");
+
+        args[0].Should().Be(@"C:\ProgramData\DotnetFleet\tools\fleet.exe");
+        args[3].Should().Be(@"C:\ProgramData\DotnetFleet\coordinator");
+    }
+
+    [Fact]
+    public void GetDefaultWindowsDataDir_UsesProgramData()
+    {
+        var dataDir = WindowsServiceManager.GetDefaultWindowsDataDir(
+            "worker-build-01",
+            @"C:\ProgramData");
+
+        dataDir.Should().Be(@"C:\ProgramData\DotnetFleet\worker-build-01");
+    }
+
+    private static void WriteConfig(string path, string token, int port)
+    {
+        var obj = new
+        {
+            jwtSecret = "jwt",
+            registrationToken = token,
+            port
+        };
+        File.WriteAllText(path, JsonSerializer.Serialize(obj));
+    }
+}


### PR DESCRIPTION
## Summary

Adds native Windows Services support for the DotnetFleet CLI service lifecycle while preserving the existing Linux systemd path.

- dispatches `fleet coordinator/worker install/status/uninstall/update` between Linux systemd and Windows SCM
- installs a service-local Windows tool under `%ProgramData%\DotnetFleet\tools` and uses `%ProgramData%\DotnetFleet\...` service data defaults
- makes coordinator/worker service hosts Windows-service aware and writes logs under `--data-dir`
- updates local coordinator discovery, README/FAQ, and regression tests for Windows service command lines and log paths

## Validation

- `dotnet test tests/DotnetFleet.Tests/DotnetFleet.Tests.csproj -v minimal`
- `dotnet build DotnetFleet.slnx -m:1 -v minimal`

Both pass. Existing NU1903 warnings remain for `System.Security.Cryptography.Xml` in the test project.

## Still needs Windows smoke testing

This was implemented and validated from Linux, so the actual SCM path still needs to be exercised on Windows:

- run elevated PowerShell and install `fleet coordinator install --port 5000`
- verify `Get-Service fleet-coordinator` and `http://localhost:5000/health`
- install a worker on the same machine without URL/token and verify it registers
- run `fleet update --skip-tool-update` and confirm services restart
- uninstall coordinator and worker services cleanly