### PR TITLE
Run solution tests before deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,15 @@ You now have managed remote execution for DotnetDeployer. Add projects from the 
 1. **Add a project** — paste a Git URL and branch in the Desktop App (or call the API).
 2. **Trigger a deploy** — click *Deploy Now* or let automatic polling detect new commits.
 3. **A worker claims the job** — atomic claim ensures only one worker wins, even under contention.
-4. **Clone and deploy** — the worker clones (or fetches) the repo with full history, then runs `dnx dotnetdeployer.tool -y`.
+4. **Clone, test and deploy** — the worker clones (or fetches) the repo with full history, tests its root solution by default, then runs `dnx dotnetdeployer.tool -y`.
 5. **Live logs** — the coordinator streams log lines via SSE; the Desktop App shows them in real time.
 6. **Repo cache** — cloned repos stay on disk for faster subsequent deploys; an LRU policy prevents disk exhaustion.
 
 ### Requirements for Target Repos
 
 Each repo you deploy must contain a **`deployer.yaml`** at the root. See the [DotnetDeployer docs](https://github.com/SuperJMN/DotnetDeployer) for the format.
+
+Deployment projects run solution tests by default. The repository root must contain exactly one `.slnx` or `.sln` file; Fleet runs a best-effort `dotnet workload restore <solution>` followed by `dotnet test <solution> -c Release --nologo`. A failing test command stops the deployment before DotnetDeployer starts. Disable **Run solution tests before deployment** when creating or editing a project to opt out. Package-only builds do not run this test gate.
 
 > The worker runs `dnx dotnetdeployer.tool -y` — .NET 10's `dnx` downloads and caches the tool automatically. No global install or tool manifest needed.
 
@@ -597,7 +599,7 @@ Each worker runs an independent loop:
 2. **Login** — exchange `(workerId, secret)` for a JWT (cached, refreshed on 401 or near-expiry).
 3. **Heartbeat** — `POST /heartbeat` on a timer so the coordinator knows it's alive.
 4. **Poll** — `POST /api/queue/next` every `PollIntervalSeconds`; claims are atomic.
-5. **Execute** — clone or fetch with full history, then run `dnx dotnetdeployer.tool -y`.
+5. **Execute** — clone or fetch with full history, run the root solution tests when enabled, then run `dnx dotnetdeployer.tool -y`.
 6. **Stream** — stdout/stderr line by line, report final status.
 
 ### Disk Management

--- a/src/DotnetDeployer.Fleet.Api.Client/FleetApiClient.cs
+++ b/src/DotnetDeployer.Fleet.Api.Client/FleetApiClient.cs
@@ -163,18 +163,31 @@ public class FleetApiClient
         response.EnsureSuccessStatusCode();
     }
 
-    public async Task<Project> CreateProjectAsync(string name, string gitUrl, string branch, int pollingIntervalMinutes = 0, string? gitToken = null)
+    public async Task<Project> CreateProjectAsync(
+        string name,
+        string gitUrl,
+        string branch,
+        int pollingIntervalMinutes = 0,
+        string? gitToken = null,
+        bool? runTestsBeforeDeploy = null)
     {
         var response = await http.PostAsJsonAsync("/api/projects",
-            new { name, gitUrl, branch, pollingIntervalMinutes, gitToken }, JsonOptions);
+            new { name, gitUrl, branch, pollingIntervalMinutes, gitToken, runTestsBeforeDeploy }, JsonOptions);
         response.EnsureSuccessStatusCode();
         return (await response.Content.ReadFromJsonAsync<Project>(JsonOptions))!;
     }
 
-    public async Task UpdateProjectAsync(Guid id, string? name = null, string? gitUrl = null, string? branch = null, int? pollingIntervalMinutes = null, string? gitToken = null)
+    public async Task UpdateProjectAsync(
+        Guid id,
+        string? name = null,
+        string? gitUrl = null,
+        string? branch = null,
+        int? pollingIntervalMinutes = null,
+        string? gitToken = null,
+        bool? runTestsBeforeDeploy = null)
     {
         var response = await http.PutAsJsonAsync($"/api/projects/{id}",
-            new { name, gitUrl, branch, pollingIntervalMinutes, gitToken }, JsonOptions);
+            new { name, gitUrl, branch, pollingIntervalMinutes, gitToken, runTestsBeforeDeploy }, JsonOptions);
         response.EnsureSuccessStatusCode();
     }
 

--- a/src/DotnetDeployer.Fleet.App/ViewModels/AddProjectViewModel.cs
+++ b/src/DotnetDeployer.Fleet.App/ViewModels/AddProjectViewModel.cs
@@ -13,6 +13,7 @@ public partial class AddProjectViewModel : ReactiveObject
     [Reactive] private string _branch = "main";
     [Reactive] private string _pollingInterval = "0";
     [Reactive] private string _gitToken = string.Empty;
+    [Reactive] private bool _runTestsBeforeDeploy = true;
     [Reactive] private string? _error;
     [Reactive] private bool _isBusy;
 
@@ -41,7 +42,7 @@ public partial class AddProjectViewModel : ReactiveObject
 
             int polling = int.TryParse(PollingInterval, out var p) ? p : 0;
             var token = string.IsNullOrWhiteSpace(GitToken) ? null : GitToken;
-            await _client.CreateProjectAsync(Name, GitUrl, Branch, polling, token);
+            await _client.CreateProjectAsync(Name, GitUrl, Branch, polling, token, RunTestsBeforeDeploy);
             return true;
         }
         catch (Exception ex)

--- a/src/DotnetDeployer.Fleet.App/ViewModels/EditProjectViewModel.cs
+++ b/src/DotnetDeployer.Fleet.App/ViewModels/EditProjectViewModel.cs
@@ -20,6 +20,7 @@ public partial class EditProjectViewModel : ReactiveObject
     [Reactive] private string _branch;
     [Reactive] private string _pollingInterval;
     [Reactive] private string _gitToken;
+    [Reactive] private bool _runTestsBeforeDeploy;
     [Reactive] private string? _error;
     [Reactive] private bool _isBusy;
 
@@ -36,6 +37,7 @@ public partial class EditProjectViewModel : ReactiveObject
         _pollingInterval = project.PollingIntervalMinutes.ToString();
         _originalToken = project.GitToken ?? string.Empty;
         _gitToken = _originalToken;
+        _runTestsBeforeDeploy = project.RunTestsBeforeDeploy;
 
         var canSave = this.WhenAnyValue(
             x => x.Name, x => x.GitUrl, x => x.Branch,
@@ -73,7 +75,8 @@ public partial class EditProjectViewModel : ReactiveObject
                 gitUrl: GitUrl,
                 branch: Branch,
                 pollingIntervalMinutes: polling,
-                gitToken: tokenToSend);
+                gitToken: tokenToSend,
+                runTestsBeforeDeploy: RunTestsBeforeDeploy);
 
             _projects?.RefreshCommand.Execute(Unit.Default).Subscribe();
             await _navigator.GoBack();

--- a/src/DotnetDeployer.Fleet.App/ViewModels/JobDetailViewModel.cs
+++ b/src/DotnetDeployer.Fleet.App/ViewModels/JobDetailViewModel.cs
@@ -180,11 +180,12 @@ public partial class JobDetailViewModel : ReactiveObject, IHaveHeader, IDisposab
     /// (e.g. "Package · deb · x64"). Keeps the UI readable without forcing
     /// the backend to localise.
     /// </summary>
-    private static string FormatPhaseName(string name)
+    internal static string FormatPhaseName(string name)
     {
         return name switch
         {
             "worker.git.clone" => "Cloning repository",
+            "worker.solution.test" => "Running solution tests",
             "worker.deployer.invoke" => "Running DotnetDeployer",
             "worker.artifacts.upload" => "Uploading package artifacts",
             "version.resolve" => "Resolving version",

--- a/src/DotnetDeployer.Fleet.App/Views/AddProjectView.axaml
+++ b/src/DotnetDeployer.Fleet.App/Views/AddProjectView.axaml
@@ -33,6 +33,10 @@
                 <TextBox Text="{Binding PollingInterval}" PlaceholderText="0" IsEnabled="{Binding !IsBusy}" />
             </StackPanel>
 
+            <CheckBox Content="Run solution tests before deployment"
+                      IsChecked="{Binding RunTestsBeforeDeploy}"
+                      IsEnabled="{Binding !IsBusy}" />
+
             <StackPanel Spacing="4">
                 <TextBlock Text="Access token (optional, for private HTTPS repos)" Opacity="0.7" FontSize="12" TextWrapping="Wrap" />
                 <TextBox Text="{Binding GitToken}"

--- a/src/DotnetDeployer.Fleet.App/Views/EditProjectView.axaml
+++ b/src/DotnetDeployer.Fleet.App/Views/EditProjectView.axaml
@@ -35,6 +35,10 @@
                 <TextBox Text="{Binding PollingInterval}" PlaceholderText="0" IsEnabled="{Binding !IsBusy}" />
             </StackPanel>
 
+            <CheckBox Content="Run solution tests before deployment"
+                      IsChecked="{Binding RunTestsBeforeDeploy}"
+                      IsEnabled="{Binding !IsBusy}" />
+
             <StackPanel Spacing="4">
                 <TextBlock Text="Access token (optional, for private HTTPS repos)" Opacity="0.7" FontSize="12" TextWrapping="Wrap" />
                 <FlexPanel Wrap="Wrap" Gap="8" AlignItems="Center">

--- a/src/DotnetDeployer.Fleet.Coordinator/CoordinatorHostBuilder.cs
+++ b/src/DotnetDeployer.Fleet.Coordinator/CoordinatorHostBuilder.cs
@@ -176,6 +176,8 @@ public static class CoordinatorHostBuilder
             await db.Database.ExecuteSqlRawAsync("ALTER TABLE \"Projects\" ADD COLUMN \"GitToken\" TEXT NULL");
         }
 
+        await EnsureRunTestsBeforeDeployColumnAsync(db);
+
         var hasCancellationRequestedAt = (await db.Database
             .SqlQueryRaw<long>("SELECT COUNT(*) AS \"Value\" FROM pragma_table_info('DeploymentJobs') WHERE name='CancellationRequestedAt'")
             .ToListAsync()).FirstOrDefault() > 0;
@@ -309,6 +311,18 @@ public static class CoordinatorHostBuilder
         {
             await db.Database.ExecuteSqlRawAsync(
                 $"ALTER TABLE \"Workers\" ADD COLUMN \"{columnName}\" {columnDefinition}");
+        }
+    }
+
+    internal static async Task EnsureRunTestsBeforeDeployColumnAsync(FleetDbContext db)
+    {
+        var exists = (await db.Database
+            .SqlQueryRaw<long>("SELECT COUNT(*) AS \"Value\" FROM pragma_table_info('Projects') WHERE name='RunTestsBeforeDeploy'")
+            .ToListAsync()).FirstOrDefault() > 0;
+        if (!exists)
+        {
+            await db.Database.ExecuteSqlRawAsync(
+                "ALTER TABLE \"Projects\" ADD COLUMN \"RunTestsBeforeDeploy\" INTEGER NOT NULL DEFAULT 1");
         }
     }
 

--- a/src/DotnetDeployer.Fleet.Coordinator/Data/FleetDbContext.cs
+++ b/src/DotnetDeployer.Fleet.Coordinator/Data/FleetDbContext.cs
@@ -33,6 +33,9 @@ public class FleetDbContext : DbContext
         {
             e.HasKey(p => p.Id);
             e.HasIndex(p => p.Name);
+            e.Property(p => p.RunTestsBeforeDeploy)
+                .HasDefaultValue(true)
+                .HasSentinel(true);
         });
 
         modelBuilder.Entity<DeploymentJob>(e =>

--- a/src/DotnetDeployer.Fleet.Coordinator/Endpoints/ProjectEndpoints.cs
+++ b/src/DotnetDeployer.Fleet.Coordinator/Endpoints/ProjectEndpoints.cs
@@ -52,14 +52,7 @@ public static class ProjectEndpoints
 
     private static async Task<IResult> Create([FromBody] CreateProjectRequest req, IFleetStorage storage)
     {
-        var project = new Project
-        {
-            Name = req.Name,
-            GitUrl = req.GitUrl,
-            Branch = req.Branch,
-            PollingIntervalMinutes = req.PollingIntervalMinutes,
-            GitToken = string.IsNullOrWhiteSpace(req.GitToken) ? null : req.GitToken
-        };
+        var project = CreateProject(req);
 
         await storage.AddProjectAsync(project);
         return Results.Created($"/api/projects/{project.Id}", project);
@@ -75,13 +68,7 @@ public static class ProjectEndpoints
         var oldBranch = project.Branch;
         var oldGitToken = project.GitToken;
 
-        project.Name = req.Name ?? project.Name;
-        project.GitUrl = req.GitUrl ?? project.GitUrl;
-        project.Branch = req.Branch ?? project.Branch;
-        if (req.PollingIntervalMinutes.HasValue)
-            project.PollingIntervalMinutes = req.PollingIntervalMinutes.Value;
-        if (req.GitToken is not null)
-            project.GitToken = string.IsNullOrWhiteSpace(req.GitToken) ? null : req.GitToken;
+        ApplyUpdate(project, req);
 
         await storage.UpdateProjectAsync(project);
         if (!string.Equals(oldGitUrl, project.GitUrl, StringComparison.Ordinal)
@@ -245,6 +232,42 @@ public static class ProjectEndpoints
         return Results.Ok(new { deleted });
     }
 
-    public record CreateProjectRequest(string Name, string GitUrl, string Branch = "main", int PollingIntervalMinutes = 0, string? GitToken = null);
-    public record UpdateProjectRequest(string? Name, string? GitUrl, string? Branch, int? PollingIntervalMinutes, string? GitToken = null);
+    internal static Project CreateProject(CreateProjectRequest req) => new()
+    {
+        Name = req.Name,
+        GitUrl = req.GitUrl,
+        Branch = req.Branch,
+        PollingIntervalMinutes = req.PollingIntervalMinutes,
+        GitToken = string.IsNullOrWhiteSpace(req.GitToken) ? null : req.GitToken,
+        RunTestsBeforeDeploy = req.RunTestsBeforeDeploy ?? true
+    };
+
+    internal static void ApplyUpdate(Project project, UpdateProjectRequest req)
+    {
+        project.Name = req.Name ?? project.Name;
+        project.GitUrl = req.GitUrl ?? project.GitUrl;
+        project.Branch = req.Branch ?? project.Branch;
+        if (req.PollingIntervalMinutes.HasValue)
+            project.PollingIntervalMinutes = req.PollingIntervalMinutes.Value;
+        if (req.GitToken is not null)
+            project.GitToken = string.IsNullOrWhiteSpace(req.GitToken) ? null : req.GitToken;
+        if (req.RunTestsBeforeDeploy.HasValue)
+            project.RunTestsBeforeDeploy = req.RunTestsBeforeDeploy.Value;
+    }
+
+    public record CreateProjectRequest(
+        string Name,
+        string GitUrl,
+        string Branch = "main",
+        int PollingIntervalMinutes = 0,
+        string? GitToken = null,
+        bool? RunTestsBeforeDeploy = null);
+
+    public record UpdateProjectRequest(
+        string? Name,
+        string? GitUrl,
+        string? Branch,
+        int? PollingIntervalMinutes,
+        string? GitToken = null,
+        bool? RunTestsBeforeDeploy = null);
 }

--- a/src/DotnetDeployer.Fleet.Core/Domain/Project.cs
+++ b/src/DotnetDeployer.Fleet.Core/Domain/Project.cs
@@ -16,6 +16,12 @@ public class Project
     /// <summary>Minutes between automatic polling checks. 0 = disabled.</summary>
     public int PollingIntervalMinutes { get; set; } = 0;
 
+    /// <summary>
+    /// Whether deployment jobs must run the repository's root solution tests before
+    /// invoking DotnetDeployer. Package build jobs never run this test gate.
+    /// </summary>
+    public bool RunTestsBeforeDeploy { get; set; } = true;
+
     public string? LastPolledCommitSha { get; set; }
     public DateTimeOffset? LastPolledAt { get; set; }
     public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;

--- a/src/DotnetDeployer.Fleet.Worker/Execution/DeployerRunner.cs
+++ b/src/DotnetDeployer.Fleet.Worker/Execution/DeployerRunner.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Threading.Channels;
 using DotnetDeployer.Fleet.Core.Domain;
 
 namespace DotnetDeployer.Fleet.WorkerService.Execution;
@@ -27,9 +26,60 @@ public static class DeployerRunner
         Func<PhaseEvent, Task>? onPhase = null,
         CancellationToken ct = default)
     {
-        var dotnet = ResolveDotnetExecutable();
+        return await RunWithProcessRunnerAsync(
+            workingDirectory,
+            onLine,
+            arguments,
+            envVars,
+            onPhase,
+            StreamingProcessRunner.Instance,
+            ct);
+    }
 
-        var psi = new ProcessStartInfo(dotnet)
+    internal static async Task<(bool Success, string? Error)> RunWithProcessRunnerAsync(
+        string workingDirectory,
+        Func<string, Task> onLine,
+        IReadOnlyList<string>? arguments,
+        IReadOnlyDictionary<string, string>? envVars,
+        Func<PhaseEvent, Task>? onPhase,
+        IStreamingProcessRunner processRunner,
+        CancellationToken ct = default)
+    {
+        var commandArguments = new List<string> { "dnx", "dotnetdeployer.tool", "-y" };
+        if (arguments is not null)
+            commandArguments.AddRange(arguments);
+
+        var psi = CreateDotnetProcessStartInfo(workingDirectory, commandArguments, envVars);
+        var exitCode = await processRunner.RunAsync(psi, async line =>
+        {
+            // Deployer phase markers are telemetry, not human-readable log lines.
+            if (onPhase is not null)
+            {
+                var ev = PhaseMarkerParser.TryParse(line);
+                if (ev is not null)
+                {
+                    try { await onPhase(ev).ConfigureAwait(false); }
+                    catch (OperationCanceledException) { throw; }
+                    catch { /* phase delivery must not tear down the build */ }
+                    return;
+                }
+            }
+
+            await onLine(line).ConfigureAwait(false);
+        }, ct);
+
+        if (exitCode != 0)
+            return (false, $"dotnetdeployer.tool exited with code {exitCode}");
+
+        return (true, null);
+    }
+
+    internal static ProcessStartInfo CreateDotnetProcessStartInfo(
+        string workingDirectory,
+        IEnumerable<string> arguments,
+        IReadOnlyDictionary<string, string>? envVars = null)
+    {
+        var psi = new ProcessStartInfo(ResolveDotnetExecutable())
         {
             WorkingDirectory = workingDirectory,
             RedirectStandardOutput = true,
@@ -37,14 +87,9 @@ public static class DeployerRunner
             UseShellExecute = false,
             CreateNoWindow = true
         };
-        psi.ArgumentList.Add("dnx");
-        psi.ArgumentList.Add("dotnetdeployer.tool");
-        psi.ArgumentList.Add("-y");
-        if (arguments is not null)
-        {
-            foreach (var arg in arguments)
-                psi.ArgumentList.Add(arg);
-        }
+
+        foreach (var argument in arguments)
+            psi.ArgumentList.Add(argument);
 
         ApplyBuildEnvironment(psi);
 
@@ -54,93 +99,7 @@ public static class DeployerRunner
                 psi.Environment[key] = value;
         }
 
-        using var process = new Process { StartInfo = psi };
-
-        // Decouple stdout/stderr capture from log delivery.
-        //
-        // Process events fire on threadpool threads. The previous design used
-        // `async void` event handlers that awaited an HTTP POST per line under a
-        // SemaphoreSlim. During noisy commands like `dotnet workload restore`
-        // (thousands of lines/sec on first run) this saturated the threadpool
-        // on small machines (e.g. Raspberry Pi 4, 4 cores) and starved the
-        // worker's heartbeat loop, which in turn caused the coordinator's
-        // stale-job reaper to mark the worker as dead and fail the job.
-        //
-        // The fix: handlers do nothing but a non-blocking enqueue into an
-        // unbounded channel. A single dedicated consumer task drains the
-        // channel and awaits onLine sequentially — preserving order without
-        // any lock and without blocking process I/O.
-        var channel = Channel.CreateUnbounded<string>(new UnboundedChannelOptions
-        {
-            SingleReader = true,
-            SingleWriter = false,
-            AllowSynchronousContinuations = false
-        });
-
-        process.OutputDataReceived += (_, e) =>
-        {
-            if (e.Data is not null) channel.Writer.TryWrite(e.Data);
-        };
-
-        process.ErrorDataReceived += (_, e) =>
-        {
-            if (e.Data is not null) channel.Writer.TryWrite($"[ERR] {e.Data}");
-        };
-
-        var consumer = Task.Run(async () =>
-        {
-            try
-            {
-                await foreach (var line in channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
-                {
-                    // Detect ##deployer[phase.*] markers and route them to onPhase.
-                    // Markers are stripped from the line stream so they don't
-                    // pollute the human-readable log.
-                    if (onPhase is not null)
-                    {
-                        var ev = PhaseMarkerParser.TryParse(line);
-                        if (ev is not null)
-                        {
-                            try { await onPhase(ev).ConfigureAwait(false); }
-                            catch (OperationCanceledException) { throw; }
-                            catch { /* never let phase-event delivery tear down the build */ }
-                            continue;
-                        }
-                    }
-
-                    try { await onLine(line).ConfigureAwait(false); }
-                    catch (OperationCanceledException) { throw; }
-                    catch { /* never let a transient log delivery failure tear down the build */ }
-                }
-            }
-            catch (OperationCanceledException) { /* expected on cancellation */ }
-        }, ct);
-
-        process.Start();
-        process.BeginOutputReadLine();
-        process.BeginErrorReadLine();
-
-        try
-        {
-            await process.WaitForExitAsync(ct).ConfigureAwait(false);
-        }
-        catch (OperationCanceledException)
-        {
-            try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
-            channel.Writer.TryComplete();
-            try { await consumer.ConfigureAwait(false); } catch { /* swallow */ }
-            throw;
-        }
-
-        // Process has exited: signal end-of-stream and let the consumer drain
-        // any buffered lines before we report completion.
-        channel.Writer.TryComplete();
-        try { await consumer.ConfigureAwait(false); } catch { /* already logged above */ }
-
-        if (process.ExitCode != 0)
-            return (false, $"dotnetdeployer.tool exited with code {process.ExitCode}");
-
-        return (true, null);
+        return psi;
     }
 
     /// <summary>

--- a/src/DotnetDeployer.Fleet.Worker/Execution/SolutionTestRunner.cs
+++ b/src/DotnetDeployer.Fleet.Worker/Execution/SolutionTestRunner.cs
@@ -1,0 +1,110 @@
+namespace DotnetDeployer.Fleet.WorkerService.Execution;
+
+internal static class SolutionTestRunner
+{
+    private const string OptOutLabel = "Run solution tests before deployment";
+
+    internal static string DiscoverRootSolution(string repositoryRoot)
+    {
+        var candidates = Directory.EnumerateFiles(repositoryRoot, "*", SearchOption.TopDirectoryOnly)
+            .Where(path =>
+            {
+                var extension = Path.GetExtension(path);
+                return extension.Equals(".slnx", StringComparison.OrdinalIgnoreCase)
+                       || extension.Equals(".sln", StringComparison.OrdinalIgnoreCase);
+            })
+            .OrderBy(path => Path.GetFileName(path), StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (candidates.Count == 1)
+            return candidates[0];
+
+        var candidateList = candidates.Count == 0
+            ? "(none)"
+            : string.Join(", ", candidates.Select(Path.GetFileName));
+
+        throw new InvalidOperationException(
+            $"Expected exactly one .slnx or .sln file in repository root '{repositoryRoot}', " +
+            $"but found {candidates.Count}. Candidates: {candidateList}. " +
+            $"Keep exactly one solution in the repository root or disable '{OptOutLabel}' for this project.");
+    }
+
+    internal static Task<(bool Success, string? Error)> RunAsync(
+        string workingDirectory,
+        Func<string, Task> onLine,
+        IReadOnlyDictionary<string, string>? envVars = null,
+        CancellationToken ct = default)
+    {
+        return RunAsync(
+            workingDirectory,
+            onLine,
+            envVars,
+            StreamingProcessRunner.Instance,
+            ct);
+    }
+
+    internal static async Task<(bool Success, string? Error)> RunAsync(
+        string workingDirectory,
+        Func<string, Task> onLine,
+        IReadOnlyDictionary<string, string>? envVars,
+        IStreamingProcessRunner processRunner,
+        CancellationToken ct = default)
+    {
+        string solution;
+        try
+        {
+            solution = DiscoverRootSolution(workingDirectory);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return (false, ex.Message);
+        }
+
+        var solutionName = Path.GetFileName(solution);
+        await onLine($"Solution test target: {solutionName}");
+
+        try
+        {
+            var restore = DeployerRunner.CreateDotnetProcessStartInfo(
+                workingDirectory,
+                ["workload", "restore", solution],
+                envVars);
+
+            var restoreExitCode = await processRunner.RunAsync(restore, onLine, ct);
+            if (restoreExitCode != 0)
+            {
+                await onLine(
+                    $"[WARN] dotnet workload restore exited with code {restoreExitCode}; continuing to dotnet test.");
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            await onLine($"[WARN] dotnet workload restore failed: {ex.Message}; continuing to dotnet test.");
+        }
+
+        try
+        {
+            var test = DeployerRunner.CreateDotnetProcessStartInfo(
+                workingDirectory,
+                ["test", solution, "-c", "Release", "--nologo"],
+                envVars);
+
+            var testExitCode = await processRunner.RunAsync(test, onLine, ct);
+            return testExitCode == 0
+                ? (true, null)
+                : (false, $"dotnet test exited with code {testExitCode}");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Could not run dotnet test: {ex.Message}");
+        }
+    }
+}

--- a/src/DotnetDeployer.Fleet.Worker/Execution/StreamingProcessRunner.cs
+++ b/src/DotnetDeployer.Fleet.Worker/Execution/StreamingProcessRunner.cs
@@ -1,0 +1,148 @@
+using System.Diagnostics;
+using System.Threading.Channels;
+
+namespace DotnetDeployer.Fleet.WorkerService.Execution;
+
+internal interface IStreamingProcessRunner
+{
+    Task<int> RunAsync(
+        ProcessStartInfo startInfo,
+        Func<string, Task> onLine,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Runs worker child processes with ordered, non-blocking stdout/stderr streaming.
+/// Cancellation always attempts to terminate the complete process tree.
+/// </summary>
+internal sealed class StreamingProcessRunner : IStreamingProcessRunner
+{
+    internal static StreamingProcessRunner Instance { get; } = new(new SystemWorkerProcessFactory());
+
+    private readonly IWorkerProcessFactory processFactory;
+
+    internal StreamingProcessRunner(IWorkerProcessFactory processFactory)
+    {
+        this.processFactory = processFactory;
+    }
+
+    public async Task<int> RunAsync(
+        ProcessStartInfo startInfo,
+        Func<string, Task> onLine,
+        CancellationToken ct = default)
+    {
+        using var process = processFactory.Create(startInfo);
+
+        // Process events must remain cheap: enqueue immediately, then let one
+        // consumer deliver logs in order without starving worker heartbeats.
+        var channel = Channel.CreateUnbounded<string>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false,
+            AllowSynchronousContinuations = false
+        });
+
+        process.OutputLine += line => channel.Writer.TryWrite(line);
+        process.ErrorLine += line => channel.Writer.TryWrite($"[ERR] {line}");
+
+        var consumer = Task.Run(async () =>
+        {
+            try
+            {
+                await foreach (var line in channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+                {
+                    try { await onLine(line).ConfigureAwait(false); }
+                    catch (OperationCanceledException) { throw; }
+                    catch { /* transient log delivery must not tear down the command */ }
+                }
+            }
+            catch (OperationCanceledException) { /* expected on cancellation */ }
+        });
+
+        try
+        {
+            process.Start();
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+        }
+        catch
+        {
+            channel.Writer.TryComplete();
+            try { await consumer.ConfigureAwait(false); } catch { /* preserve start error */ }
+            throw;
+        }
+
+        try
+        {
+            await process.WaitForExitAsync(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
+            channel.Writer.TryComplete();
+            try { await consumer.ConfigureAwait(false); } catch { /* preserve cancellation */ }
+            throw;
+        }
+
+        channel.Writer.TryComplete();
+        try { await consumer.ConfigureAwait(false); } catch { /* log delivery is best effort */ }
+
+        return process.ExitCode;
+    }
+}
+
+internal interface IWorkerProcessFactory
+{
+    IWorkerProcess Create(ProcessStartInfo startInfo);
+}
+
+internal interface IWorkerProcess : IDisposable
+{
+    event Action<string> OutputLine;
+    event Action<string> ErrorLine;
+
+    int ExitCode { get; }
+
+    void Start();
+    void BeginOutputReadLine();
+    void BeginErrorReadLine();
+    Task WaitForExitAsync(CancellationToken ct);
+    void Kill(bool entireProcessTree);
+}
+
+internal sealed class SystemWorkerProcessFactory : IWorkerProcessFactory
+{
+    public IWorkerProcess Create(ProcessStartInfo startInfo) => new SystemWorkerProcess(startInfo);
+}
+
+internal sealed class SystemWorkerProcess : IWorkerProcess
+{
+    private readonly Process process;
+
+    public SystemWorkerProcess(ProcessStartInfo startInfo)
+    {
+        process = new Process { StartInfo = startInfo };
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data is not null)
+                OutputLine(e.Data);
+        };
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data is not null)
+                ErrorLine(e.Data);
+        };
+    }
+
+    public event Action<string> OutputLine = delegate { };
+    public event Action<string> ErrorLine = delegate { };
+
+    public int ExitCode => process.ExitCode;
+
+    public void Start() => process.Start();
+    public void BeginOutputReadLine() => process.BeginOutputReadLine();
+    public void BeginErrorReadLine() => process.BeginErrorReadLine();
+    public Task WaitForExitAsync(CancellationToken ct) => process.WaitForExitAsync(ct);
+    public void Kill(bool entireProcessTree) => process.Kill(entireProcessTree);
+    public void Dispose() => process.Dispose();
+}

--- a/src/DotnetDeployer.Fleet.Worker/Execution/WorkerDeploymentPipeline.cs
+++ b/src/DotnetDeployer.Fleet.Worker/Execution/WorkerDeploymentPipeline.cs
@@ -1,0 +1,26 @@
+using DotnetDeployer.Fleet.Core.Domain;
+
+namespace DotnetDeployer.Fleet.WorkerService.Execution;
+
+internal static class WorkerDeploymentPipeline
+{
+    internal static bool ShouldRunSolutionTests(DeploymentJob job, Project project) =>
+        job.Kind == JobKind.Deploy && project.RunTestsBeforeDeploy;
+
+    internal static async Task<(bool Success, string? Error)> RunAsync(
+        DeploymentJob job,
+        Project project,
+        Func<CancellationToken, Task<(bool Success, string? Error)>> runSolutionTests,
+        Func<CancellationToken, Task<(bool Success, string? Error)>> runDeployer,
+        CancellationToken ct = default)
+    {
+        if (ShouldRunSolutionTests(job, project))
+        {
+            var testResult = await runSolutionTests(ct);
+            if (!testResult.Success)
+                return testResult;
+        }
+
+        return await runDeployer(ct);
+    }
+}

--- a/src/DotnetDeployer.Fleet.Worker/RemoteWorkerBackgroundService.cs
+++ b/src/DotnetDeployer.Fleet.Worker/RemoteWorkerBackgroundService.cs
@@ -278,30 +278,76 @@ public class RemoteWorkerBackgroundService : BackgroundService
 
                 var deployerArguments = BuildDeployerArguments(job, packageOutputDir);
 
-                await Log(job.Kind == JobKind.PackageBuild
-                    ? "=== Invoking DotnetDeployer (package-only) ==="
-                    : "=== Invoking DotnetDeployer ===");
+                async Task<(bool Success, string? Error)> RunSolutionTestsAsync(CancellationToken token)
+                {
+                    await Log("=== Running solution tests ===");
+                    await EmitPhaseAsync(job.Id, PhaseEventKind.Start, "worker.solution.test", ct: token);
+                    var testSw = System.Diagnostics.Stopwatch.StartNew();
+                    (bool Success, string? Error) result = (false, null);
 
-                // worker.deployer.invoke wraps the entire DotnetDeployer process. The
-                // marker stream parsed by DeployerRunner produces nested phases
-                // (version.resolve, package.generate.*, github.release.upload, …)
-                // that the coordinator persists alongside this one.
-                await EmitPhaseAsync(job.Id, PhaseEventKind.Start, "worker.deployer.invoke",
-                    ct: jobCt);
-                var deploySw = System.Diagnostics.Stopwatch.StartNew();
+                    try
+                    {
+                        result = await SolutionTestRunner.RunAsync(
+                            localPath,
+                            onLine: line => logBuffer.AppendAsync(line),
+                            envVars: envVars,
+                            ct: token);
 
-                var (success, error) = await DeployerRunner.RunAsync(
-                    localPath,
-                    onLine: line => logBuffer.AppendAsync(line),
-                    arguments: deployerArguments,
-                    envVars: envVars,
-                    onPhase: ev => jobSource.PostJobPhaseAsync(job.Id, ev, jobCt),
-                    ct: jobCt);
+                        await Log(result.Success
+                            ? "=== Solution tests SUCCEEDED ==="
+                            : $"=== Solution tests FAILED: {result.Error} ===");
+                        return result;
+                    }
+                    finally
+                    {
+                        testSw.Stop();
+                        await EmitPhaseAsync(job.Id, PhaseEventKind.End, "worker.solution.test",
+                            status: result.Success ? PhaseStatus.Ok : PhaseStatus.Fail,
+                            durationMs: testSw.ElapsedMilliseconds, ct: token);
+                        await logBuffer.FlushAsync();
+                    }
+                }
 
-                deploySw.Stop();
-                await EmitPhaseAsync(job.Id, PhaseEventKind.End, "worker.deployer.invoke",
-                    status: success ? PhaseStatus.Ok : PhaseStatus.Fail,
-                    durationMs: deploySw.ElapsedMilliseconds, ct: jobCt);
+                async Task<(bool Success, string? Error)> RunDeployerAsync(CancellationToken token)
+                {
+                    await Log(job.Kind == JobKind.PackageBuild
+                        ? "=== Invoking DotnetDeployer (package-only) ==="
+                        : "=== Invoking DotnetDeployer ===");
+
+                    // worker.deployer.invoke wraps the entire DotnetDeployer process. The
+                    // marker stream parsed by DeployerRunner produces nested phases
+                    // (version.resolve, package.generate.*, github.release.upload, …)
+                    // that the coordinator persists alongside this one.
+                    await EmitPhaseAsync(job.Id, PhaseEventKind.Start, "worker.deployer.invoke", ct: token);
+                    var deploySw = System.Diagnostics.Stopwatch.StartNew();
+                    (bool Success, string? Error) result = (false, null);
+
+                    try
+                    {
+                        result = await DeployerRunner.RunAsync(
+                            localPath,
+                            onLine: line => logBuffer.AppendAsync(line),
+                            arguments: deployerArguments,
+                            envVars: envVars,
+                            onPhase: ev => jobSource.PostJobPhaseAsync(job.Id, ev, token),
+                            ct: token);
+                        return result;
+                    }
+                    finally
+                    {
+                        deploySw.Stop();
+                        await EmitPhaseAsync(job.Id, PhaseEventKind.End, "worker.deployer.invoke",
+                            status: result.Success ? PhaseStatus.Ok : PhaseStatus.Fail,
+                            durationMs: deploySw.ElapsedMilliseconds, ct: token);
+                    }
+                }
+
+                var (success, error) = await WorkerDeploymentPipeline.RunAsync(
+                    job,
+                    project,
+                    RunSolutionTestsAsync,
+                    RunDeployerAsync,
+                    jobCt);
 
                 await logBuffer.FlushAsync();
 

--- a/tests/DotnetDeployer.Fleet.Tests/AddProjectViewModelTests.cs
+++ b/tests/DotnetDeployer.Fleet.Tests/AddProjectViewModelTests.cs
@@ -32,6 +32,14 @@ public class AddProjectViewModelTests
     }
 
     [Fact]
+    public void Solution_tests_are_enabled_by_default()
+    {
+        var vm = CreateViewModel();
+
+        vm.RunTestsBeforeDeploy.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task TrySaveAsync_ShouldRejectMissingRequiredFields()
     {
         var vm = CreateViewModel();

--- a/tests/DotnetDeployer.Fleet.Tests/EditProjectViewModelTests.cs
+++ b/tests/DotnetDeployer.Fleet.Tests/EditProjectViewModelTests.cs
@@ -1,0 +1,34 @@
+using DotnetDeployer.Fleet.Api.Client;
+using DotnetDeployer.Fleet.App.ViewModels;
+using DotnetDeployer.Fleet.Core.Domain;
+using ReactiveUI.Builder;
+using Zafiro.UI.Navigation;
+
+namespace DotnetDeployer.Fleet.Tests;
+
+public sealed class EditProjectViewModelTests
+{
+    static EditProjectViewModelTests()
+    {
+        RxAppBuilder.CreateReactiveUIBuilder()
+            .WithCoreServices()
+            .BuildApp();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Loads_persisted_solution_test_setting(bool runTestsBeforeDeploy)
+    {
+        var project = new Project { RunTestsBeforeDeploy = runTestsBeforeDeploy };
+        var client = new FleetApiClient(new HttpClientHandler(), new HttpClientHandler());
+
+        var vm = new EditProjectViewModel(
+            project,
+            client,
+            Substitute.For<INavigator>(),
+            projectsForRefresh: null);
+
+        vm.RunTestsBeforeDeploy.Should().Be(runTestsBeforeDeploy);
+    }
+}

--- a/tests/DotnetDeployer.Fleet.Tests/JobDetailViewModelHeaderTests.cs
+++ b/tests/DotnetDeployer.Fleet.Tests/JobDetailViewModelHeaderTests.cs
@@ -53,6 +53,13 @@ public sealed class JobDetailViewModelHeaderTests
         action.IsSecondaryCommand.Should().BeFalse();
     }
 
+    [Fact]
+    public void Solution_test_phase_has_a_readable_label()
+    {
+        JobDetailViewModel.FormatPhaseName("worker.solution.test")
+            .Should().Be("Running solution tests");
+    }
+
     private static JobDetailViewModel CreateViewModel(DeploymentJob job)
     {
         var client = CreateClient(job);

--- a/tests/DotnetDeployer.Fleet.Tests/ProjectTestSettingsApiTests.cs
+++ b/tests/DotnetDeployer.Fleet.Tests/ProjectTestSettingsApiTests.cs
@@ -1,0 +1,83 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using DotnetDeployer.Fleet.Api.Client;
+using DotnetDeployer.Fleet.Coordinator.Endpoints;
+using DotnetDeployer.Fleet.Core.Domain;
+
+namespace DotnetDeployer.Fleet.Tests;
+
+public sealed class ProjectTestSettingsApiTests
+{
+    [Fact]
+    public void Create_request_without_setting_enables_tests()
+    {
+        var request = JsonSerializer.Deserialize<ProjectEndpoints.CreateProjectRequest>("""
+            {
+              "name": "App",
+              "gitUrl": "https://example.com/app.git"
+            }
+            """, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        var project = ProjectEndpoints.CreateProject(request!);
+
+        project.RunTestsBeforeDeploy.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Update_request_can_disable_reenable_and_leave_setting_unchanged()
+    {
+        var project = new Project { RunTestsBeforeDeploy = true };
+
+        ProjectEndpoints.ApplyUpdate(project, Update(runTestsBeforeDeploy: false));
+        project.RunTestsBeforeDeploy.Should().BeFalse();
+
+        ProjectEndpoints.ApplyUpdate(project, Update(runTestsBeforeDeploy: null));
+        project.RunTestsBeforeDeploy.Should().BeFalse();
+
+        ProjectEndpoints.ApplyUpdate(project, Update(runTestsBeforeDeploy: true));
+        project.RunTestsBeforeDeploy.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Fleet_client_sends_test_setting_on_create_and_update()
+    {
+        var requests = new List<(HttpMethod Method, string Body)>();
+        var handler = new StubHandler(async request =>
+        {
+            requests.Add((request.Method, await request.Content!.ReadAsStringAsync()));
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = request.Method == HttpMethod.Post
+                    ? JsonContent.Create(new Project())
+                    : null
+            };
+        });
+        var client = new FleetApiClient(handler, handler);
+        client.SetBaseAddress("http://localhost:5000");
+
+        await client.CreateProjectAsync(
+            "App",
+            "https://example.com/app.git",
+            "main",
+            runTestsBeforeDeploy: false);
+        await client.UpdateProjectAsync(Guid.NewGuid(), runTestsBeforeDeploy: true);
+
+        requests.Should().HaveCount(2);
+        requests[0].Method.Should().Be(HttpMethod.Post);
+        requests[0].Body.Should().Contain("\"runTestsBeforeDeploy\":false");
+        requests[1].Method.Should().Be(HttpMethod.Put);
+        requests[1].Body.Should().Contain("\"runTestsBeforeDeploy\":true");
+    }
+
+    private static ProjectEndpoints.UpdateProjectRequest Update(bool? runTestsBeforeDeploy) =>
+        new(null, null, null, null, RunTestsBeforeDeploy: runTestsBeforeDeploy);
+
+    private sealed class StubHandler(
+        Func<HttpRequestMessage, Task<HttpResponseMessage>> handle) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) => handle(request);
+    }
+}

--- a/tests/DotnetDeployer.Fleet.Tests/ProjectTestSettingsPersistenceTests.cs
+++ b/tests/DotnetDeployer.Fleet.Tests/ProjectTestSettingsPersistenceTests.cs
@@ -1,0 +1,92 @@
+using DotnetDeployer.Fleet.Coordinator;
+using DotnetDeployer.Fleet.Coordinator.Data;
+using DotnetDeployer.Fleet.Core.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace DotnetDeployer.Fleet.Tests;
+
+public sealed class ProjectTestSettingsPersistenceTests : IDisposable
+{
+    private readonly string dbPath = Path.Combine(
+        Path.GetTempPath(),
+        $"fleet-project-tests-{Guid.NewGuid():N}.db");
+
+    [Fact]
+    public async Task New_projects_enable_solution_tests_by_default_and_allow_opt_out()
+    {
+        var options = CreateOptions();
+        await using (var db = new FleetDbContext(options))
+        {
+            await db.Database.EnsureCreatedAsync();
+            db.Projects.AddRange(
+                new Project { Name = "default", GitUrl = "https://example.com/default.git" },
+                new Project
+                {
+                    Name = "opt-out",
+                    GitUrl = "https://example.com/opt-out.git",
+                    RunTestsBeforeDeploy = false
+                });
+            await db.SaveChangesAsync();
+        }
+
+        await using var verify = new FleetDbContext(options);
+        var projects = await verify.Projects.OrderBy(project => project.Name).ToListAsync();
+
+        projects.Single(project => project.Name == "default").RunTestsBeforeDeploy.Should().BeTrue();
+        projects.Single(project => project.Name == "opt-out").RunTestsBeforeDeploy.Should().BeFalse();
+
+        projects.Single(project => project.Name == "default").RunTestsBeforeDeploy = false;
+        projects.Single(project => project.Name == "opt-out").RunTestsBeforeDeploy = true;
+        await verify.SaveChangesAsync();
+        verify.ChangeTracker.Clear();
+
+        var updated = await verify.Projects.OrderBy(project => project.Name).ToListAsync();
+        updated.Single(project => project.Name == "default").RunTestsBeforeDeploy.Should().BeFalse();
+        updated.Single(project => project.Name == "opt-out").RunTestsBeforeDeploy.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Existing_database_projects_are_migrated_with_tests_enabled()
+    {
+        var options = CreateOptions();
+        await using var db = new FleetDbContext(options);
+        await db.Database.ExecuteSqlRawAsync("""
+            CREATE TABLE "Projects" (
+                "Id" TEXT NOT NULL CONSTRAINT "PK_Projects" PRIMARY KEY,
+                "Name" TEXT NOT NULL,
+                "GitUrl" TEXT NOT NULL,
+                "Branch" TEXT NOT NULL,
+                "PollingIntervalMinutes" INTEGER NOT NULL,
+                "CreatedAt" INTEGER NOT NULL
+            )
+            """);
+        await db.Database.ExecuteSqlRawAsync("""
+            INSERT INTO "Projects"
+                ("Id", "Name", "GitUrl", "Branch", "PollingIntervalMinutes", "CreatedAt")
+            VALUES
+                ('00000000-0000-0000-0000-000000000001', 'legacy', 'https://example.com/legacy.git', 'main', 0, 0)
+            """);
+
+        await CoordinatorHostBuilder.EnsureRunTestsBeforeDeployColumnAsync(db);
+
+        var values = await db.Database
+            .SqlQueryRaw<long>("SELECT \"RunTestsBeforeDeploy\" AS \"Value\" FROM \"Projects\"")
+            .ToListAsync();
+        var defaults = await db.Database
+            .SqlQueryRaw<string>("SELECT dflt_value AS \"Value\" FROM pragma_table_info('Projects') WHERE name='RunTestsBeforeDeploy'")
+            .ToListAsync();
+
+        values.Should().Equal(1);
+        defaults.Should().Equal("1");
+    }
+
+    private DbContextOptions<FleetDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<FleetDbContext>()
+            .UseSqlite($"Data Source={dbPath}")
+            .Options;
+
+    public void Dispose()
+    {
+        try { File.Delete(dbPath); } catch { /* best effort */ }
+    }
+}

--- a/tests/DotnetDeployer.Fleet.Tests/SolutionTestRunnerTests.cs
+++ b/tests/DotnetDeployer.Fleet.Tests/SolutionTestRunnerTests.cs
@@ -1,0 +1,133 @@
+using System.Diagnostics;
+using DotnetDeployer.Fleet.WorkerService.Execution;
+
+namespace DotnetDeployer.Fleet.Tests;
+
+public sealed class SolutionTestRunnerTests : IDisposable
+{
+    private readonly string repositoryRoot = Path.Combine(
+        Path.GetTempPath(),
+        $"fleet-solution-tests-{Guid.NewGuid():N}");
+
+    public SolutionTestRunnerTests()
+    {
+        Directory.CreateDirectory(repositoryRoot);
+    }
+
+    [Theory]
+    [InlineData("App.slnx")]
+    [InlineData("App.sln")]
+    [InlineData("App.SLNX")]
+    public void Discovers_exactly_one_supported_root_solution(string fileName)
+    {
+        var expected = Path.Combine(repositoryRoot, fileName);
+        File.WriteAllText(expected, string.Empty);
+
+        var solution = SolutionTestRunner.DiscoverRootSolution(repositoryRoot);
+
+        solution.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Missing_solution_reports_candidates_and_opt_out()
+    {
+        var act = () => SolutionTestRunner.DiscoverRootSolution(repositoryRoot);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*found 0*Candidates: (none)*disable 'Run solution tests before deployment'*");
+    }
+
+    [Fact]
+    public void Multiple_solutions_report_every_candidate()
+    {
+        File.WriteAllText(Path.Combine(repositoryRoot, "Legacy.sln"), string.Empty);
+        File.WriteAllText(Path.Combine(repositoryRoot, "Modern.slnx"), string.Empty);
+
+        var act = () => SolutionTestRunner.DiscoverRootSolution(repositoryRoot);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*found 2*Legacy.sln, Modern.slnx*");
+    }
+
+    [Fact]
+    public async Task Runs_best_effort_workload_restore_then_release_tests_with_build_environment()
+    {
+        var solution = Path.Combine(repositoryRoot, "App.slnx");
+        File.WriteAllText(solution, string.Empty);
+        var processRunner = new RecordingProcessRunner(restoreExitCode: 9, testExitCode: 0);
+        var lines = new List<string>();
+        var secrets = new Dictionary<string, string> { ["DEPLOY_TOKEN"] = "secret-value" };
+
+        var result = await SolutionTestRunner.RunAsync(
+            repositoryRoot,
+            line =>
+            {
+                lines.Add(line);
+                return Task.CompletedTask;
+            },
+            secrets,
+            processRunner);
+
+        result.Success.Should().BeTrue();
+        processRunner.Commands.Should().HaveCount(2);
+        processRunner.Commands[0].Arguments.Should().Equal("workload", "restore", solution);
+        processRunner.Commands[1].Arguments.Should().Equal(
+            "test", solution, "-c", "Release", "--nologo");
+        processRunner.Commands.Should().OnlyContain(command => command.WorkingDirectory == repositoryRoot);
+        processRunner.Commands.Should().OnlyContain(command => command.Environment["DEPLOY_TOKEN"] == "secret-value");
+        processRunner.Commands.Should().OnlyContain(command => command.Environment["UseSharedCompilation"] == "false");
+        lines.Should().ContainInOrder("process output 1", "process output 2");
+        lines.Should().Contain(line => line.Contains("continuing to dotnet test", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Failing_dotnet_test_returns_a_failed_gate_result()
+    {
+        File.WriteAllText(Path.Combine(repositoryRoot, "App.sln"), string.Empty);
+        var processRunner = new RecordingProcessRunner(restoreExitCode: 0, testExitCode: 7);
+
+        var result = await SolutionTestRunner.RunAsync(
+            repositoryRoot,
+            _ => Task.CompletedTask,
+            envVars: null,
+            processRunner);
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Be("dotnet test exited with code 7");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(repositoryRoot, recursive: true); } catch { /* best effort */ }
+    }
+
+    private sealed class RecordingProcessRunner(params int[] exitCodes) : IStreamingProcessRunner
+    {
+        private readonly Queue<int> exitCodes = new(exitCodes);
+
+        public RecordingProcessRunner(int restoreExitCode, int testExitCode)
+            : this([restoreExitCode, testExitCode])
+        {
+        }
+
+        public List<CapturedCommand> Commands { get; } = [];
+
+        public async Task<int> RunAsync(
+            ProcessStartInfo startInfo,
+            Func<string, Task> onLine,
+            CancellationToken ct = default)
+        {
+            Commands.Add(new CapturedCommand(
+                startInfo.WorkingDirectory,
+                startInfo.ArgumentList.ToList(),
+                startInfo.Environment.ToDictionary(pair => pair.Key, pair => pair.Value ?? string.Empty)));
+            await onLine($"process output {Commands.Count}");
+            return exitCodes.Dequeue();
+        }
+    }
+
+    private sealed record CapturedCommand(
+        string WorkingDirectory,
+        IReadOnlyList<string> Arguments,
+        IReadOnlyDictionary<string, string> Environment);
+}

--- a/tests/DotnetDeployer.Fleet.Tests/StreamingProcessRunnerTests.cs
+++ b/tests/DotnetDeployer.Fleet.Tests/StreamingProcessRunnerTests.cs
@@ -1,0 +1,100 @@
+using System.Diagnostics;
+using DotnetDeployer.Fleet.WorkerService.Execution;
+
+namespace DotnetDeployer.Fleet.Tests;
+
+public sealed class StreamingProcessRunnerTests
+{
+    [Fact]
+    public async Task Streams_stdout_and_stderr_through_the_ordered_process_boundary()
+    {
+        var process = new ControllableProcess(exitCode: 3)
+        {
+            OutputOnStart = "standard output",
+            ErrorOnStart = "standard error"
+        };
+        var runner = new StreamingProcessRunner(new ControllableProcessFactory(process));
+        var lines = new List<string>();
+
+        var exitCode = await runner.RunAsync(
+            new ProcessStartInfo("dotnet"),
+            line =>
+            {
+                lines.Add(line);
+                return Task.CompletedTask;
+            });
+
+        exitCode.Should().Be(3);
+        lines.Should().Equal("standard output", "[ERR] standard error");
+        process.OutputReadStarted.Should().BeTrue();
+        process.ErrorReadStarted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Cancellation_terminates_the_entire_process_tree()
+    {
+        var process = new ControllableProcess(exitCode: 0) { WaitUntilCancelled = true };
+        var runner = new StreamingProcessRunner(new ControllableProcessFactory(process));
+        using var cts = new CancellationTokenSource();
+
+        var running = runner.RunAsync(
+            new ProcessStartInfo("dotnet"),
+            _ => Task.CompletedTask,
+            cts.Token);
+        await cts.CancelAsync();
+
+        await FluentActions.Awaiting(() => running).Should().ThrowAsync<OperationCanceledException>();
+        process.KillCalled.Should().BeTrue();
+        process.KilledEntireProcessTree.Should().BeTrue();
+    }
+
+    private sealed class ControllableProcessFactory(ControllableProcess process) : IWorkerProcessFactory
+    {
+        public IWorkerProcess Create(ProcessStartInfo startInfo)
+        {
+            process.StartInfo = startInfo;
+            return process;
+        }
+    }
+
+    private sealed class ControllableProcess(int exitCode) : IWorkerProcess
+    {
+        public event Action<string> OutputLine = delegate { };
+        public event Action<string> ErrorLine = delegate { };
+
+        public ProcessStartInfo? StartInfo { get; set; }
+        public string? OutputOnStart { get; init; }
+        public string? ErrorOnStart { get; init; }
+        public bool WaitUntilCancelled { get; init; }
+        public bool OutputReadStarted { get; private set; }
+        public bool ErrorReadStarted { get; private set; }
+        public bool KillCalled { get; private set; }
+        public bool KilledEntireProcessTree { get; private set; }
+        public int ExitCode { get; } = exitCode;
+
+        public void Start()
+        {
+            if (OutputOnStart is not null)
+                OutputLine(OutputOnStart);
+            if (ErrorOnStart is not null)
+                ErrorLine(ErrorOnStart);
+        }
+
+        public void BeginOutputReadLine() => OutputReadStarted = true;
+        public void BeginErrorReadLine() => ErrorReadStarted = true;
+
+        public Task WaitForExitAsync(CancellationToken ct) => WaitUntilCancelled
+            ? Task.Delay(Timeout.InfiniteTimeSpan, ct)
+            : Task.CompletedTask;
+
+        public void Kill(bool entireProcessTree)
+        {
+            KillCalled = true;
+            KilledEntireProcessTree = entireProcessTree;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tests/DotnetDeployer.Fleet.Tests/WorkerDeploymentPipelineTests.cs
+++ b/tests/DotnetDeployer.Fleet.Tests/WorkerDeploymentPipelineTests.cs
@@ -1,0 +1,84 @@
+using DotnetDeployer.Fleet.Core.Domain;
+using DotnetDeployer.Fleet.WorkerService.Execution;
+
+namespace DotnetDeployer.Fleet.Tests;
+
+public sealed class WorkerDeploymentPipelineTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Manual_and_automatic_deploys_run_tests_before_deployer(bool isAutoTriggered)
+    {
+        var job = new DeploymentJob { Kind = JobKind.Deploy, IsAutoTriggered = isAutoTriggered };
+        var project = new Project { RunTestsBeforeDeploy = true };
+        var calls = new List<string>();
+
+        var result = await WorkerDeploymentPipeline.RunAsync(
+            job,
+            project,
+            _ =>
+            {
+                calls.Add("tests");
+                return Task.FromResult<(bool, string?)>((true, null));
+            },
+            _ =>
+            {
+                calls.Add("deployer");
+                return Task.FromResult<(bool, string?)>((true, null));
+            });
+
+        result.Success.Should().BeTrue();
+        calls.Should().Equal("tests", "deployer");
+    }
+
+    [Fact]
+    public async Task Failed_tests_block_DotnetDeployer()
+    {
+        var deployerCalls = 0;
+
+        var result = await WorkerDeploymentPipeline.RunAsync(
+            new DeploymentJob { Kind = JobKind.Deploy },
+            new Project { RunTestsBeforeDeploy = true },
+            _ => Task.FromResult<(bool, string?)>((false, "tests failed")),
+            _ =>
+            {
+                deployerCalls++;
+                return Task.FromResult<(bool, string?)>((true, null));
+            });
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Be("tests failed");
+        deployerCalls.Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData(JobKind.Deploy, false)]
+    [InlineData(JobKind.PackageBuild, true)]
+    [InlineData(JobKind.PackageBuild, false)]
+    public async Task Disabled_projects_and_package_builds_skip_solution_tests(
+        JobKind kind,
+        bool runTestsBeforeDeploy)
+    {
+        var testCalls = 0;
+        var deployerCalls = 0;
+
+        var result = await WorkerDeploymentPipeline.RunAsync(
+            new DeploymentJob { Kind = kind },
+            new Project { RunTestsBeforeDeploy = runTestsBeforeDeploy },
+            _ =>
+            {
+                testCalls++;
+                return Task.FromResult<(bool, string?)>((true, null));
+            },
+            _ =>
+            {
+                deployerCalls++;
+                return Task.FromResult<(bool, string?)>((true, null));
+            });
+
+        result.Success.Should().BeTrue();
+        testCalls.Should().Be(0);
+        deployerCalls.Should().Be(1);
+    }
+}


### PR DESCRIPTION
## Summary

- enable solution tests by default for new and existing projects, with an opt-out in the add/edit UI and public API
- discover exactly one root `.slnx` or `.sln`, run tolerant workload restore, then run Release tests before DotnetDeployer
- skip tests for package builds or disabled projects and stop deployment when tests fail
- stream test output through the worker process infrastructure, including environment, secrets, and process-tree cancellation
- document the default behavior and root-solution requirement

## Validation

- `dotnet test DotnetDeployer.Fleet.slnx -c Release --nologo --no-build --no-restore` (293 passed)
- focused worker, persistence, API, and ViewModel tests (28 passed)
- touched-file formatting and `git diff --check`
- Avalonia MCP runtime check: default checked, toggle works, and disabled value persists when editing